### PR TITLE
updated panel width

### DIFF
--- a/apps/front-end/src/theme/GlobalCSSVariables.tsx
+++ b/apps/front-end/src/theme/GlobalCSSVariables.tsx
@@ -17,7 +17,7 @@ const rootVariables = {
   "--spacing-xlarge": "32px",
   "--spacing-xxlarge": "40px",
   "--spacing-xxxlarge": "48px",
-  "--panel-width-desktop": "450px",
+  "--panel-width-desktop": "400px",
   "--font-size-xsmall": "12px",
   "--font-size-small": "14px",
   "--font-size-medium": "16px",


### PR DESCRIPTION
#### What? Why?

Related to @rogup's comment on PR [#18](https://github.com/DigitalCommons/mykomap-monolith/pull/18), which relates to [issue #272](https://github.com/DigitalCommons/mykomap/issues/272)

Width of the panel looks too wide compared to designs.

- Compared width of the panel component to its respective design
   - The widths were the same, but perhaps the screen ratio of the designs made the panel looks smaller.
- Reduced the desktop panel width from 450px to 400px.
   - This can be easily amended at any time by updating the value of the CSS variable `--panel-width-desktop` within `GlobalCSSVariables.tsx` file.

![image](https://github.com/user-attachments/assets/25d9e1a8-1a16-4d6e-909d-169a2d098f21)



#### What should we test?
#### What should we test?
- Run storybook
```npm run storybook``` 
- Should run open automatically in your browser (or  VS Code click dialogue as shown below)

![image](https://github.com/user-attachments/assets/332e576c-1925-470f-939d-d21664cf2e29)

- Select a component to test

![image](https://github.com/user-attachments/assets/801a6774-4162-4ba8-9f3a-b10e03d19129)


#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass
