### PR TITLE
Tidy back end tests

### DIFF
--- a/apps/back-end/test/plugin.test.ts
+++ b/apps/back-end/test/plugin.test.ts
@@ -69,3 +69,16 @@ test("testing getConfig", async (t) => {
   });
   expect(res.statusCode).toBe(200);
 });
+
+test("testing getVersion", async (t) => {
+  const fastify = Fastify();
+  fastify.register(fastifyPlugin, opts);
+
+  const res = await fastify.inject({
+    method: "GET",
+    url: "/version",
+    payload: undefined,
+    headers: undefined,
+  });
+  expect(res.statusCode).toBe(200);
+});

--- a/apps/back-end/test/plugin.test.ts
+++ b/apps/back-end/test/plugin.test.ts
@@ -18,7 +18,7 @@ const opts: MykomapRouterConfig = {
 // Note: see src/api/contract.ts in the @mykomap/common module for definitions
 // and documentation of the API.
 
-test("testing dataset", async (t) => {
+test("testing getDatasetLocations", async (t) => {
   const fastify = Fastify();
   fastify.register(fastifyPlugin, opts);
 
@@ -31,7 +31,7 @@ test("testing dataset", async (t) => {
   expect(res.statusCode).toBe(200);
 });
 
-test("testing datasetSearch", async (t) => {
+test("testing searchDataset", async (t) => {
   const fastify = Fastify();
   fastify.register(fastifyPlugin, opts);
 
@@ -44,7 +44,7 @@ test("testing datasetSearch", async (t) => {
   expect(res.statusCode).toBe(200);
 });
 
-test("testing datasetItem", async (t) => {
+test("testing getDatasetItem", async (t) => {
   const fastify = Fastify();
   fastify.register(fastifyPlugin, opts);
 

--- a/apps/back-end/test/plugin.test.ts
+++ b/apps/back-end/test/plugin.test.ts
@@ -15,38 +15,8 @@ const opts: MykomapRouterConfig = {
   },
 };
 
-//
-// Operation: dataset
-// URL: /dataset/:datasetId/locations
-// summary:  obtains a dataset
-// req.params
-//   type: object
-//   properties:
-//     datasetId:
-//       type: string
-//       description: uniquely specifies the dataset wanted
-//   required:
-//     - datasetId
-//
-// valid responses
-//   '200':
-//     description: the dataset matching the supplied criteria
-//     content:
-//       application/json:
-//         schema:
-//           type: array
-//           items:
-//             maxItems: 2
-//             minItems: 2
-//             type: array
-//             items:
-//               type: number
-//               format: float32
-//   '400':
-//     description: bad input parameter
-//   '404':
-//     description: no such dataset
-//
+// Note: see src/api/contract.ts in the @mykomap/common module for definitions
+// and documentation of the API.
 
 test("testing dataset", async (t) => {
   const fastify = Fastify();
@@ -61,46 +31,6 @@ test("testing dataset", async (t) => {
   expect(res.statusCode).toBe(200);
 });
 
-// Operation: datasetSearch
-// URL: /dataset/:datasetId/search
-// summary:  obtains a list of dataset entries satisfying the search criteria supplied
-// req.params
-//   type: object
-//   properties:
-//     datasetId:
-//       type: string
-//       description: uniquely specifies the dataset wanted
-//   required:
-//     - datasetId
-//
-// req.query
-//   type: object
-//   properties:
-//     text:
-//       type: string
-//       description: a text fragment to match
-//     filter:
-//       type: array
-//       items:
-//         type: string
-//       description: uniquely specifies the taxonomy filter items wanted
-//
-// valid responses
-//   '200':
-//     description: the dataset IDs matching the supplied criteria
-//     content:
-//       application/json:
-//         schema:
-//           type: array
-//           items:
-//             type: string
-//             description: uniquely specifies the dataset item wanted
-//   '400':
-//     description: bad input parameter
-//   '404':
-//     description: no such dataset
-//
-
 test("testing datasetSearch", async (t) => {
   const fastify = Fastify();
   fastify.register(fastifyPlugin, opts);
@@ -113,35 +43,6 @@ test("testing datasetSearch", async (t) => {
   });
   expect(res.statusCode).toBe(200);
 });
-
-// Operation: datasetItem
-// URL: /dataset/:datasetId/item/:datasetItemId
-// summary:  obtains a dataset item by its  unique ID
-// req.params
-//   type: object
-//   properties:
-//     datasetId:
-//       type: string
-//       description: uniquely specifies the dataset wanted
-//     datasetItemId:
-//       type: string
-//       description: uniquely specifies the dataset item wanted
-//   required:
-//     - datasetId
-//     - datasetItemId
-//
-// valid responses
-//   '200':
-//     description: the dataset item matching the supplied criteria
-//     content:
-//       application/json:
-//         schema:
-//           type: object
-//   '400':
-//     description: bad input parameter
-//   '404':
-//     description: no such dataset item
-//
 
 test("testing datasetItem", async (t) => {
   const fastify = Fastify();

--- a/apps/back-end/test/plugin.test.ts
+++ b/apps/back-end/test/plugin.test.ts
@@ -56,3 +56,16 @@ test("testing getDatasetItem", async (t) => {
   });
   expect(res.statusCode).toBe(200);
 });
+
+test("testing getConfig", async (t) => {
+  const fastify = Fastify();
+  fastify.register(fastifyPlugin, opts);
+
+  const res = await fastify.inject({
+    method: "GET",
+    url: "/dataset/test-A/config",
+    payload: undefined,
+    headers: undefined,
+  });
+  expect(res.statusCode).toBe(200);
+});


### PR DESCRIPTION

#### What? Why?

No related issue.

In the process of creting the branch for the previous PRs (#35), I noticed that the back-end tests included 
- out of date descriptions and comments
- missing endpoint tests (`getVersion` and `getConfig`)

These are addressed in this branch as a cleaning-up job.

#### What should we test?

Run the tests, they should all pass.
Check the changes to `plugin.test.ts` source looks sensible.

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [x] Added UTs
- [x] Checked that all automated tests pass

#### Deployment notes
