### PR TITLE
[front-end] Assorted UI fixes

### DIFF
--- a/apps/front-end/src/components/map/mapLibre.ts
+++ b/apps/front-end/src/components/map/mapLibre.ts
@@ -1,5 +1,5 @@
 import * as MapLibreGL from "maplibre-gl";
-import { NavigationControl, Popup } from "maplibre-gl";
+import { AttributionControl, NavigationControl, Popup } from "maplibre-gl";
 import type {
   Map,
   GeoJSONSource,
@@ -121,6 +121,7 @@ export const createMap = (): Map => {
       [-180, -59.9],
       [180, 78.1],
     ],
+    attributionControl: false,
   });
 
   map.on("load", () => {
@@ -285,7 +286,8 @@ export const createMap = (): Map => {
       map.getCanvas().style.cursor = "";
     });
 
-    map.addControl(new NavigationControl(), "bottom-right");
+    map.addControl(new AttributionControl(), "top-right");
+    map.addControl(new NavigationControl(), "top-right");
     disableRotation(map);
   });
 

--- a/apps/front-end/src/components/panel/Panel.tsx
+++ b/apps/front-end/src/components/panel/Panel.tsx
@@ -20,18 +20,28 @@ import {
 } from "./panelSlice";
 
 const StyledPanel = styled(Drawer)(() => ({
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
   flexShrink: 0,
   width: "calc(var(--panel-width-desktop) + 30px)",
   position: "relative",
   overflow: "visible",
+  backgroundColor: "#fff",
   "& .MuiDrawer-paper": {
     width: "var(--panel-width-desktop)",
     boxSizing: "border-box",
-    backgroundColor: "#fff",
     visibility: "visible !important",
     overflow: "visible",
     boxShadow: "0 0 20px rgba(0, 0, 0, 0.16)",
   },
+}));
+
+const StyledBox = styled(Box)(() => ({
+  flexShrink: 0,
+  position: "relative",
+  overflow: "visible",
+  backgroundColor: "#fff",
 }));
 
 const Panel = () => {
@@ -70,59 +80,47 @@ const Panel = () => {
 
   return (
     <>
-      {/* Container for testing only */}
-      <Box
-        sx={{
-          height: "100vh",
-          display: "flex",
-          flexDirection: "column",
-          backgroundColor: "#E2DFD2",
-        }}
-      >
-        {/* Desktop view  */}
-        {isMedium && (
-          <Box>
-            <StyledPanel variant="persistent" open={isOpen} anchor="left">
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  height: "100%",
-                }}
-              >
-                <NavBar
-                  onTabChange={handleTabChange}
-                  selectedTab={selectedTab}
-                />
-                {/* <Box sx={{ flexGrow: 1 }}> */}
-                  {selectedTab === 0 && <DirectoryPanel />}
-                  {selectedTab === 1 && <SearchPanel />}
-                  {selectedTab === 2 && <AboutPanel />}
-                {/* </Box> */}
-              </Box>
-              <PanelToggleButton buttonAction={handleToggle} isOpen={isOpen} />
-            </StyledPanel>
-          </Box>
-        )}
+      {/* Desktop view  */}
+      {isMedium && (
+        <Box>
+          <StyledPanel variant="persistent" open={isOpen} anchor="left">
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                height: "100%",
+              }}
+            >
+              <NavBar onTabChange={handleTabChange} selectedTab={selectedTab} />
+              {selectedTab === 0 && <DirectoryPanel />}
+              {selectedTab === 1 && <SearchPanel />}
+              {selectedTab === 2 && <AboutPanel />}
+            </Box>
+            <PanelToggleButton buttonAction={handleToggle} isOpen={isOpen} />
+          </StyledPanel>
+        </Box>
+      )}
 
-        {/* Mobile view  */}
-        {!isMedium && (
+      {/* Mobile view  */}
+      {!isMedium && (
+        <StyledBox>
           <Box
             sx={{
               flexGrow: 1,
               display: "flex",
               flexDirection: "column",
-              height: "100%",
+              height: selectedTab !== 0 ? "calc(100vh - 60px)" : "auto",
+              "@media screen and (min-height: 415px)": {
+                height: selectedTab !== 0 ? "calc(100vh - 80px)" : "auto",
+              },
             }}
           >
             {panelVisible && (
               <>
                 <CloseButton buttonAction={handlePanelClose} />
-                <Box sx={{ flexGrow: 1, backgroundColor: "#fff" }}>
-                  {selectedTab === 1 && <DirectoryPanel />}
-                  {selectedTab === 2 && <SearchPanel />}
-                  {selectedTab === 3 && <AboutPanel />}
-                </Box>
+                {selectedTab === 1 && <DirectoryPanel />}
+                {selectedTab === 2 && <SearchPanel />}
+                {selectedTab === 3 && <AboutPanel />}
               </>
             )}
             <Box
@@ -141,8 +139,8 @@ const Panel = () => {
               />
             </Box>
           </Box>
-        )}
-      </Box>
+        </StyledBox>
+      )}
     </>
   );
 };

--- a/apps/front-end/src/components/panel/Panel.tsx
+++ b/apps/front-end/src/components/panel/Panel.tsx
@@ -26,6 +26,7 @@ const StyledPanel = styled(Drawer)(() => ({
   flexShrink: 0,
   width: "calc(var(--panel-width-desktop) + 30px)",
   position: "relative",
+  zIndex: 3,
   overflow: "visible",
   backgroundColor: "#fff",
   "& .MuiDrawer-paper": {
@@ -40,6 +41,7 @@ const StyledPanel = styled(Drawer)(() => ({
 const StyledBox = styled(Box)(() => ({
   flexShrink: 0,
   position: "relative",
+  zIndex: 3,
   overflow: "visible",
   backgroundColor: "#fff",
 }));

--- a/apps/front-end/src/components/panel/contentPanel/ContentPanel.tsx
+++ b/apps/front-end/src/components/panel/contentPanel/ContentPanel.tsx
@@ -18,10 +18,8 @@ const StyledContentPanel = styled(Box)(() => ({
   },
 }));
 
-const ContentPanel = ({children}: ContentPanelProps) => {
-  return (
-    <StyledContentPanel>{children}</StyledContentPanel>
-  )
-}
+const ContentPanel = ({ children }: ContentPanelProps) => {
+  return <StyledContentPanel>{children}</StyledContentPanel>;
+};
 
-export default ContentPanel
+export default ContentPanel;

--- a/apps/front-end/src/components/panel/directoryPanel/DirectoryPanel.stories.tsx
+++ b/apps/front-end/src/components/panel/directoryPanel/DirectoryPanel.stories.tsx
@@ -8,7 +8,7 @@ import GlobalCSSVariables from "../../../theme/GlobalCSSVariables";
 // Simulate a click event on a link within the DirectoryPanel
 const clickInteraction = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
-  const links = await canvas.getAllByRole("link"); // Get all links in the panel
+  const links = await canvas.getAllByRole("button"); // Get all links in the panel
 
   links.forEach((link) => {
     link.addEventListener("click", (e) => e.preventDefault()); // Prevent navigation for all links

--- a/apps/front-end/src/components/panel/directoryPanel/DirectoryPanel.tsx
+++ b/apps/front-end/src/components/panel/directoryPanel/DirectoryPanel.tsx
@@ -2,31 +2,31 @@ import Heading from "../heading/Heading";
 import DirectoryItem from "./directoryItem/DirectoryItem";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import Link from "@mui/material/Link";
+import Button from "@mui/material/Button";
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 
 // Mock data
-const countries = [
-  { id: "1", name: "Argentina", link: "" },
-  { id: "2", name: "Australia", link: "" },
-  { id: "3", name: "Austria", link: "" },
-  { id: "4", name: "Bangladesh", link: "" },
-  { id: "5", name: "Barbados", link: "" },
-  { id: "6", name: "Belarus", link: "" },
-  { id: "7", name: "Belgium", link: "" },
-  { id: "8", name: "Bolivia", link: "" },
-  { id: "9", name: "Brazil", link: "" },
-  { id: "10", name: "Bulgaria", link: "" },
-  { id: "11", name: "Canada", link: "" },
-  { id: "12", name: "Chile", link: "" },
-  { id: "13", name: "China", link: "" },
-  { id: "14", name: "Colombia", link: "" },
-  { id: "15", name: "Costa Rica", link: "" },
-  { id: "16", name: "Côte d'Ivoire", link: "" },
-  { id: "17", name: "Curaçao", link: "" },
-  { id: "18", name: "Cyprus", link: "" },
-  { id: "19", name: "Czechia", link: "" },
+const countries: { id: string; name: string }[] = [
+  { id: "1", name: "Argentina" },
+  { id: "2", name: "Australia" },
+  { id: "3", name: "Austria" },
+  { id: "4", name: "Bangladesh" },
+  { id: "5", name: "Barbados" },
+  { id: "6", name: "Belarus" },
+  { id: "7", name: "Belgium" },
+  { id: "8", name: "Bolivia" },
+  { id: "9", name: "Brazil" },
+  { id: "10", name: "Bulgaria" },
+  { id: "11", name: "Canada" },
+  { id: "12", name: "Chile" },
+  { id: "13", name: "China" },
+  { id: "14", name: "Colombia" },
+  { id: "15", name: "Costa Rica" },
+  { id: "16", name: "Côte d'Ivoire" },
+  { id: "17", name: "Curaçao" },
+  { id: "18", name: "Cyprus" },
+  { id: "19", name: "Czechia" },
 ];
 
 interface DirectoryPanelProps {
@@ -46,27 +46,43 @@ const StyledDirectoryPanel = styled(Box)(() => ({
   },
 }));
 
-const StyledLink = styled(Link)(() => ({
-  color: "var(--color-primary)",
+const StyledButton = styled(Button)(() => ({
+  width: "100%",
+  padding: "var(--spacing-small) var(--spacing-medium)",
   display: "block",
+  fontSize: "var(--font-size-medium)",
+  fontWeight: "var(--font-weight-medium)",
+  textDecoration: "none",
+  textAlign: "left",
+  color: "var(--color-primary)",
+  backgroundColor: "transparent",
+  borderRadius: 0,
+  boxShadow: "none",
   "&:hover": {
     backgroundColor: "var(--color-neutral-light)",
   },
+  "@media (min-width: 768px)": {
+    padding: "var(--spacing-small) var(--spacing-large)",
+  },
 }));
 
-const DirectoryPanel = ({onClick}: DirectoryPanelProps) => {
+const DirectoryPanel = ({ onClick }: DirectoryPanelProps) => {
+  const showAllEntries = () => {
+    console.log("Show all entries");
+  };
+
   return (
     <>
       <Heading title="Directory" />
       <StyledDirectoryPanel>
         <List>
           <ListItem>
-            <StyledLink href="" role="link" onClick={onClick}>
+            <StyledButton role="button" onClick={showAllEntries}>
               All Entries
-            </StyledLink>
+            </StyledButton>
           </ListItem>
           {countries.map((country) => (
-            <DirectoryItem key={country.id} {...country} link={country.link} />
+            <DirectoryItem key={country.id} {...country} />
           ))}
         </List>
       </StyledDirectoryPanel>

--- a/apps/front-end/src/components/panel/directoryPanel/directoryItem/DirectoryItem.stories.tsx
+++ b/apps/front-end/src/components/panel/directoryPanel/directoryItem/DirectoryItem.stories.tsx
@@ -8,7 +8,7 @@ import GlobalCSSVariables from "../../../../theme/GlobalCSSVariables";
 // Simulate a click event on a link
 const clickInteraction = async (canvasElement: HTMLElement) => {
   const canvas = within(canvasElement);
-  const link = await canvas.getByRole("link");
+  const link = await canvas.getByRole("button");
   await userEvent.click(link);
 };
 

--- a/apps/front-end/src/components/panel/directoryPanel/directoryItem/DirectoryItem.tsx
+++ b/apps/front-end/src/components/panel/directoryPanel/directoryItem/DirectoryItem.tsx
@@ -1,25 +1,44 @@
 import ListItem from "@mui/material/ListItem";
 import { styled } from "@mui/material/styles";
-import Link from "@mui/material/Link";
+import Button from "@mui/material/Button";
 
 interface DirectoryItemProps {
   id: string;
   name: string;
-  link: string;
   onClick?: (e: React.MouseEvent) => void; // for storybook testing
 }
 
-const StyledLink = styled(Link)(() => ({
+const StyledButton = styled(Button)(() => ({
+  width: "100%",
+  padding: "var(--spacing-small) var(--spacing-medium)",
+  display: "block",
+  fontSize: "var(--font-size-medium)",
+  fontWeight: "var(--font-weight-medium)",
+  textDecoration: "none",
+  textAlign: "left",
   color: "var(--color-text)",
+  backgroundColor: "transparent",
+  borderRadius: 0,
+  boxShadow: "none",
   "&:hover": {
     backgroundColor: "var(--color-neutral-light)",
   },
+  "@media (min-width: 768px)": {
+    padding: "var(--spacing-small) var(--spacing-large)",
+  },
 }));
 
-const DirectoryItem = ({ id, name, link, onClick }: DirectoryItemProps) => {
+const DirectoryItem = ({ id, name, onClick }: DirectoryItemProps) => {
+  const handleClick = (e: React.MouseEvent) => {
+    console.log(`Clicked ${name}`);
+    if (onClick) onClick(e); // Optional for storybook testing
+  };
+
   return (
     <ListItem key={id}>
-      <StyledLink href={link} role="link" onClick={onClick}>{name}</StyledLink>
+      <StyledButton role="button" onClick={handleClick}>
+        {name}
+      </StyledButton>
     </ListItem>
   );
 };

--- a/apps/front-end/src/components/panel/searchPanel/SearchPanel.tsx
+++ b/apps/front-end/src/components/panel/searchPanel/SearchPanel.tsx
@@ -37,7 +37,7 @@ const SearchPanel = () => {
   };
 
   return (
-    <form className="mx-auto max-w-md" onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       <Heading title="Search">
         <SearchBox
           value={currentText}

--- a/apps/front-end/src/components/panel/searchPanel/SearchPanel.tsx
+++ b/apps/front-end/src/components/panel/searchPanel/SearchPanel.tsx
@@ -36,6 +36,13 @@ const SearchPanel = () => {
     dispatch(performSearch());
   };
 
+  const onClear = () => {
+    console.log("Clearing search");
+    setCurrentText("");
+    dispatch(setText(""));
+    dispatch(performSearch());
+  };
+
   return (
     <form onSubmit={onSubmit}>
       <Heading title="Search">
@@ -43,6 +50,7 @@ const SearchPanel = () => {
           value={currentText}
           onChange={onSearchChange}
           onSubmit={onSubmit}
+          clearSearch={onClear}
         />
       </Heading>
       <ContentPanel>

--- a/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
+++ b/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
@@ -1,16 +1,16 @@
-import React from "react";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import InputAdornment from "@mui/material/InputAdornment";
-import { IconButton } from "@mui/material";
+import Box from "@mui/material/Box";
 import SearchIcon from "@mui/icons-material/Search";
 import { styled } from "@mui/material/styles";
+import IconButton from "@mui/material/IconButton";
+import CancelIcon from "@mui/icons-material/Cancel";
 
 const StyledSearchBox = styled(OutlinedInput)(() => ({
   width: "100%",
   borderRadius: "var(--border-radius-small)",
   backgroundColor: "#fff",
   color: "var(--color-text)",
-  marginTop: "var(--spacing-medium)",
   "& .MuiOutlinedInput-notchedOutline": {
     borderColor: "transparent",
   },
@@ -28,33 +28,77 @@ const StyledSearchBox = styled(OutlinedInput)(() => ({
   },
 }));
 
+const StyledIconButton = styled(IconButton)(() => ({
+  height: 18,
+  width: 18,
+  position: "absolute",
+  top: "50%",
+  right: "var(--spacing-xsmall)",
+  transform: "translate(-50%, -50%)",
+  color: "var(--color-text)",
+}));
+
 interface SearchBoxProps {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSubmit: (
     e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => void;
+  clearSearch?: () => void;
 }
 
-const SearchBox = ({ value, onChange, onSubmit }: SearchBoxProps) => {
+const SearchBox = ({
+  value,
+  onChange,
+  onSubmit,
+  clearSearch,
+}: SearchBoxProps) => {
   return (
-    <StyledSearchBox
-      id="search-input"
-      value={value}
-      onChange={onChange}
-      onKeyUp={(event) => {
-        if (event.key === "Enter") onSubmit(event);
-      }}
-      autoComplete="off"
-      placeholder="Search for initiatives..."
-      startAdornment={
-        <InputAdornment position="end">
-          <IconButton aria-label="search-button" disableRipple>
-            <SearchIcon />
-          </IconButton>
-        </InputAdornment>
-      }
-    />
+    <Box sx={{ position: "relative", marginTop: "var(--spacing-medium)" }}>
+      <StyledSearchBox
+        id="search-input"
+        value={value}
+        onChange={onChange}
+        onKeyUp={(event) => {
+          if (event.key === "Enter") onSubmit(event);
+        }}
+        autoComplete="off"
+        placeholder="Search for initiatives..."
+        startAdornment={
+          <InputAdornment position="end">
+            <IconButton aria-label="search-button" disableRipple>
+              <SearchIcon />
+            </IconButton>
+          </InputAdornment>
+        }
+      />
+      {value && (
+        <StyledIconButton onClick={clearSearch} aria-label="clear-search">
+          <Box
+            sx={{
+              height: 16,
+              width: 16,
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+              backgroundColor: "#fff",
+              borderRadius: "50%",
+            }}
+          />
+          <CancelIcon
+            sx={{
+              height: 18,
+              width: 18,
+              position: "absolute",
+              top: "50%",
+              left: "50%",
+              transform: "translate(-50%, -50%)",
+            }}
+          />
+        </StyledIconButton>
+      )}
+    </Box>
   );
 };
 


### PR DESCRIPTION
#### What? Why?

UI fixes linked to comments in PR [https://github.com/DigitalCommons/mykomap-monolith/pull/40](https://github.com/DigitalCommons/mykomap-monolith/pull/40)

- **Backgrounds missing on mobile panels**
- **Content of desktop search panel not stretching to full width**
- **Added Clear search button / functionality**
- **As discussed with @rogup  directory panel hyperlinks to buttons**

@rogup, directory panel has a simple click function that adds location coordinates to the console. Also I'm not about until Tuesday now so feel free to merge in if all is ok.

#### Backgrounds missing on mobile panels and MapLibre controls ovelapping nav
![image](https://github.com/user-attachments/assets/23a039cf-ec28-487b-bc64-417a0ade042b)

#### Content of desktop search panel not stretching to full width
![image](https://github.com/user-attachments/assets/e9580fd7-e912-439d-9421-c7eb89bf4d05)


#### What should we test?

Run the app and:
- Check the panels display correctly in mobile view
- Check the search box is full width in desktop view
- Check that these changes have not affected current functionality
- Type something into the search box
   - make sure the clear icon appears
   - click on the icon and make sure text is cleared

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass

#### Notes
There is still some superfluous mark-up in the panel component, but I'm loathed to remove this until I've checked that it won't adversely affect the display of proper data.
