### PR TITLE
add PropDefs to config

### DIFF
--- a/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
+++ b/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
@@ -91,13 +91,13 @@ export const searchSlice = createAppSlice({
   extraReducers: (builder) => {
     builder.addCase(configLoaded, (state, action) => {
       const config = action.payload;
-      state.filterableFields = config.ui.filterableFields.map((field) => {
-        const fieldDef = config.fields[field] as VocabPropDef;
+      state.filterableFields = config.ui.filterableFields.map((name) => {
+        const propDef = config.itemProps[name] as VocabPropDef;
         return {
-          id: field,
+          id: name,
           value: FIELD_VALUE_ANY,
-          vocabUri: fieldDef.uri,
-          titleUri: fieldDef.titleUri,
+          vocabUri: propDef.uri,
+          titleUri: propDef.titleUri,
         };
       });
     });

--- a/apps/front-end/src/data/mockConfig.ts
+++ b/apps/front-end/src/data/mockConfig.ts
@@ -18,10 +18,10 @@ const mockConfig: Config = {
       // "data_sources", TODO: re-add this once we can handle multi vocabs
     ],
   },
-  fields: {
-    id: "value",
-    name: "value",
-    description: "value",
+  itemProps: {
+    id: { type: "value" },
+    name: { type: "value" },
+    description: { type: "value" },
     website: {
       type: "multi",
       of: {
@@ -51,11 +51,11 @@ const mockConfig: Config = {
       uri: "bmt",
       titleUri: "ui:typology",
     },
-    latitude: "value",
-    longitude: "value",
-    geocontainer_lat: "value",
-    geocontainer_lon: "value",
-    geocoded_addr: "value",
+    latitude: { type: "value" },
+    longitude: { type: "value" },
+    geocontainer_lat: { type: "value" },
+    geocontainer_lon: { type: "value" },
+    geocoded_addr: { type: "value" },
     data_sources: {
       type: "multi",
       of: { type: "vocab", uri: "dso" },

--- a/apps/front-end/src/services/index.ts
+++ b/apps/front-end/src/services/index.ts
@@ -20,7 +20,6 @@ export type Config = ClientInferResponseBody<typeof contract.getConfig, 200> & {
     filterableFields: string[];
     directory_panel_field: string;
   };
-  fields: ConfigPropDefs;
 };
 
 // TODO: we can remove these types, once the full structure of the config JSON has been added to the

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -57,9 +57,45 @@ const VocabDef = z.object({
 });
 const I18nVocabDefs = z.record(Iso639Set1Code, VocabDef);
 const VocabIndex = z.record(NCName, I18nVocabDefs);
+
+// The following specs shoud match the types in prop-spec.ts
+const FilterSpec = z.object({ preset: z.literal(true), to: z.unknown() });
+const CommonPropSpec = z.object({
+  from: z.string().optional(),
+  titleUri: z.string().optional(),
+  filter: z.union([FilterSpec, z.boolean()]).optional(),
+  search: z.boolean().optional(),
+});
+const InnerValuePropSpec = z.object({
+  type: z.literal("value"),
+  as: z
+    .union([z.literal("string"), z.literal("boolean"), z.literal("number")])
+    .optional(),
+  strict: z.boolean().optional(),
+});
+const InnerVocabPropSpec = z.object({
+  type: z.literal("vocab"),
+  uri: z.union([PrefixUri, QName]),
+});
+const InnerPropSpec = z.union([InnerValuePropSpec, InnerVocabPropSpec]);
+const OuterMultiPropSpec = z.object({
+  type: z.literal("multi"),
+  of: InnerPropSpec,
+});
+const ValuePropSpec = CommonPropSpec.merge(InnerValuePropSpec);
+const VocabPropSpec = CommonPropSpec.merge(InnerVocabPropSpec);
+const MultiPropSpec = CommonPropSpec.merge(OuterMultiPropSpec);
+const PropSpec = z.discriminatedUnion("type", [
+  ValuePropSpec,
+  VocabPropSpec,
+  MultiPropSpec,
+]);
+const PropSpecs = z.record(z.string(), PropSpec);
+
 const ConfigData = z.object({
   prefixes: PrefixIndex,
   vocabs: VocabIndex,
+  itemProps: PropSpecs,
 });
 const VersionInfo = z.object({
   name: z.string(),
@@ -79,15 +115,21 @@ export const schemas = {
   DatasetItemIx,
   DatasetItem,
   Dataset,
+  FilterSpec,
   I18nVocabDefs,
   Iso639Set1Code,
+  MultiPropSpec,
   NCName,
   PrefixUri,
   PrefixIndex,
+  PropSpec,
+  PropSpecs,
   QName,
+  ValuePropSpec,
   VersionInfo,
   VocabDef,
   VocabIndex,
+  VocabPropSpec,
   ErrorInfo,
 };
 

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -86,6 +86,7 @@ export const schemas = {
   PrefixIndex,
   QName,
   VersionInfo,
+  VocabDef,
   VocabIndex,
   ErrorInfo,
 };

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -47,6 +47,8 @@ const DatasetItemIdOrIx = ZodRegex(
 // documentation for Rx.PrefixUri.
 const PrefixUri = ZodRegex(Rx.PrefixUri, "Invalid prefix URI format");
 const PrefixIndex = z.record(PrefixUri, NCName);
+const AbbrevUri = ZodRegex(Rx.AbbrevUri, "Invalid abbreviated URI format");
+
 // Zod.enum needs some hand-holding to be happy with using object keys, as it wants a
 // guaranteed non-zero length list
 const [lang0, ...langs] = Object.keys(Iso639Set1Codes);
@@ -75,7 +77,7 @@ const InnerValuePropSpec = z.object({
 });
 const InnerVocabPropSpec = z.object({
   type: z.literal("vocab"),
-  uri: z.union([PrefixUri, QName]),
+  uri: AbbrevUri,
 });
 const InnerPropSpec = z.union([InnerValuePropSpec, InnerVocabPropSpec]);
 const OuterMultiPropSpec = z.object({
@@ -107,6 +109,7 @@ const VersionInfo = z.object({
 const ErrorInfo = z.object({ message: z.string() }).passthrough();
 
 export const schemas = {
+  AbbrevUri,
   Location,
   ConfigData,
   DatasetId,

--- a/libs/common/src/api/mykomap-openapi.json
+++ b/libs/common/src/api/mykomap-openapi.json
@@ -307,11 +307,226 @@
                           ]
                         }
                       }
+                    },
+                    "itemProps": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "discriminator": {
+                          "propertyName": "type"
+                        },
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string"
+                              },
+                              "titleUri": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "preset": {
+                                        "type": "boolean",
+                                        "enum": [
+                                          true
+                                        ]
+                                      },
+                                      "to": {
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "preset"
+                                    ]
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  }
+                                ]
+                              },
+                              "search": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "value"
+                                ]
+                              },
+                              "as": {
+                                "type": "string",
+                                "enum": [
+                                  "string",
+                                  "boolean",
+                                  "number"
+                                ]
+                              },
+                              "strict": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "type"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string"
+                              },
+                              "titleUri": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "preset": {
+                                        "type": "boolean",
+                                        "enum": [
+                                          true
+                                        ]
+                                      },
+                                      "to": {
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "preset"
+                                    ]
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  }
+                                ]
+                              },
+                              "search": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "vocab"
+                                ]
+                              },
+                              "uri": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "uri"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "type": "string"
+                              },
+                              "titleUri": {
+                                "type": "string"
+                              },
+                              "filter": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "preset": {
+                                        "type": "boolean",
+                                        "enum": [
+                                          true
+                                        ]
+                                      },
+                                      "to": {
+                                        "nullable": true
+                                      }
+                                    },
+                                    "required": [
+                                      "preset"
+                                    ]
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  }
+                                ]
+                              },
+                              "search": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "multi"
+                                ]
+                              },
+                              "of": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "value"
+                                        ]
+                                      },
+                                      "as": {
+                                        "type": "string",
+                                        "enum": [
+                                          "string",
+                                          "boolean",
+                                          "number"
+                                        ]
+                                      },
+                                      "strict": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "type"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "vocab"
+                                        ]
+                                      },
+                                      "uri": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "uri"
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "of"
+                            ]
+                          }
+                        ]
+                      }
                     }
                   },
                   "required": [
                     "prefixes",
-                    "vocabs"
+                    "vocabs",
+                    "itemProps"
                   ]
                 }
               }

--- a/libs/common/src/common-types.ts
+++ b/libs/common/src/common-types.ts
@@ -1,0 +1,24 @@
+/** Defines some utility types */
+
+/** Maps any type K to a type V
+ *
+ * Elements are explicitly optional, courtesy of Partial
+ */
+export type Assoc<K extends keyof any, V> = Partial<Record<K, V>>;
+
+/** Maps strings to a type V (which defaults to string)
+ *
+ * Elements are explicitly optional, courtesy of Partial
+ */
+export type Dictionary<V = string> = Assoc<string, V>;
+
+/** A 2 dimensional point tuple */
+export type Point2d = [number, number];
+
+/** A 2 dimensional bounding box */
+export type Box2d = [Point2d, Point2d];
+
+/** Clears all the keys from an object */
+export function clear<V>(obj: Assoc<string, V>) {
+  Object.keys(obj).forEach((key) => delete obj[key]);
+}

--- a/libs/common/src/index.ts
+++ b/libs/common/src/index.ts
@@ -1,4 +1,8 @@
 import specification from "./api/mykomap-openapi.json";
-export { contract, schemas } from "./api/contract.js";
-
 export { specification };
+export * from "./api/contract.js";
+export * from "./utils.js";
+export * from "./common-types.js";
+export * from "./text-search.js";
+export * from "./prop-specs.js";
+export * from "./prop-defs.js";

--- a/libs/common/src/prop-defs.ts
+++ b/libs/common/src/prop-defs.ts
@@ -1,0 +1,248 @@
+/** Property definitions for defining a map item's properties dynamically.
+ *
+ * These are concrete classes implementing the relevant PropSpec interfaces.
+ *
+ */
+
+import {
+  CommonPropSpec,
+  FilterSpec,
+  InnerPropSpec,
+  MultiPropSpec,
+  PropSpec,
+  PropSpecs,
+  ValuePropSpec,
+  VocabPropSpec,
+} from "./prop-specs.js";
+
+import { stringify } from "./utils.js";
+import { schemas } from "./api/contract.js";
+import { z } from "zod";
+
+// Infer the types of various contract values....
+type VocabDef = z.infer<typeof schemas.VocabDef>;
+type I18nVocabDefs = z.infer<typeof schemas.I18nVocabDefs>;
+type VocabIndex = z.infer<typeof schemas.VocabIndex>;
+type Iso639Set1Code = z.infer<typeof schemas.Iso639Set1Code>;
+type NCName = z.infer<typeof schemas.NCName>;
+
+/** The part of a property definition that is meaningfully inside a multiple */
+export type InnerDef = VocabPropDef | ValuePropDef;
+
+/** The top-level definition of a property definition. */
+export type PropDef = VocabPropDef | ValuePropDef | MultiPropDef;
+
+/** Services for creating and using PropDefs */
+export class PropDefServices {
+  private readonly _vocabs: VocabIndex;
+  private readonly lang: Iso639Set1Code;
+
+  /** Constructor.
+   *
+   * @param vocabs - all the vocab definitions we will require to create VocabPropDefs.
+   * @param lang - the language to create VocabPropDefs in by default.
+   */
+  constructor(vocabs: VocabIndex, lang: Iso639Set1Code) {
+    this._vocabs = schemas.VocabIndex.parse(vocabs);
+    this.lang = schemas.Iso639Set1Code.parse(lang);
+
+    // Sanity check the languages are defined
+    const invalidVocabIds: NCName[] = [];
+    for (const vocabId in this._vocabs) {
+      const vocab = this._vocabs[vocabId];
+      if (lang in vocab) continue;
+
+      invalidVocabIds.push(vocabId);
+    }
+
+    if (invalidVocabIds.length) {
+      throw new Error(
+        `PropDefServices initialised with these Vocabs which are incompatible ` +
+          `with the target language '${lang}': ${invalidVocabIds}`,
+      );
+    }
+  }
+
+  /** Looks up an interationalised vocab given its URI */
+  i18nVocab(uri: NCName): I18nVocabDefs {
+    const abbrev = uri.replace(/:$/, ""); // Strip the trailing colon from this (assumed) abbrev URI
+    const vocab = this._vocabs[abbrev];
+    if (vocab == null) throw new Error(`unknown vocab URI: '${uri}'`);
+    return vocab;
+  }
+
+  /** Looks up a localised vocab, given its URI and a language code */
+  vocabDef(uri: NCName, lang: Iso639Set1Code): VocabDef {
+    const i18nVocab = this.i18nVocab(uri);
+    const vocab = i18nVocab[lang];
+    if (vocab == null)
+      throw new Error(
+        `no terms defined for language code '${lang}' in vocab '${uri}'`,
+      );
+    return vocab;
+  }
+
+  /** Make a PropDef from a PropSpec
+   *
+   * @param def = the specification to use.
+   * @returns a PropDef instance of the approriate type.
+   */
+  mkPropDef(def: ValuePropSpec): ValuePropDef;
+  mkPropDef(def: VocabPropSpec): VocabPropDef;
+  mkPropDef(def: MultiPropSpec): MultiPropDef;
+  mkPropDef(def: InnerPropSpec): InnerDef;
+  mkPropDef(def: PropSpec): PropDef;
+  mkPropDef(def: PropSpec): PropDef {
+    switch (def.type) {
+      case "value":
+        return new ValuePropDef(def);
+      case "vocab":
+        return new VocabPropDef(def, this.vocabDef(def.uri, this.lang));
+      case "multi":
+        // We can cast this safely as we know that InnerSpec -> InnerDef
+        const of = this.mkPropDef(def.of);
+        return new MultiPropDef({ ...def, of });
+    }
+  }
+
+  /** Make a Record of indexed PropDefs from a Dictionary of ProfSpecs
+   *
+   *
+   * @param defs - a Dictionary of PropSpecs.
+   * @returns A record of PropDefs, indexed by the same keys as the
+   * relevant PropSpec.
+   *
+   * A Dictionary may have undefined elements; a Record, by definition, doesn't.
+   * This function should honour that, and guarantee none.
+   */
+  mkPropDefs(defs: PropSpecs): PropDefs {
+    const result: Record<string, PropDef> = {};
+    for (const propName in defs) {
+      const propDef = defs[propName];
+      if (propDef == undefined) continue;
+
+      result[propName] = this.mkPropDef(propDef);
+    }
+
+    return result;
+  }
+}
+
+/** The common parts of a PropDef.
+ *
+ */
+export abstract class CommonPropDef implements CommonPropSpec {
+  readonly from?: string;
+  readonly titleUri?: string;
+  readonly filter: FilterSpec | boolean;
+  readonly search: boolean;
+
+  /** Constructor.
+   *
+   * @param init - the specification to use
+   */
+  constructor(init: PropSpec) {
+    this.from = init.from;
+    this.titleUri = init.titleUri;
+    this.filter = init.filter ?? false;
+    this.search = !!init.search;
+  }
+
+  /** Get the text form of a value
+   *
+   * @returns a value depending on the type of PropDef. If it is a MultiPropDef,
+   * an array of strings is returned (which may be empty). Otherwise a single
+   * string will be, or an undefined value if the property is undefined.
+   */
+  abstract textForValue(value: unknown): string | string[] | undefined;
+
+  /** @return true if and only if a filter should be created for this PropDef */
+  isFiltered() {
+    return !!this.filter;
+  }
+}
+
+/** A PropDef representing a single (possibly absent) text value
+ */
+export class ValuePropDef extends CommonPropDef implements ValuePropSpec {
+  /** The type specifier */
+  readonly type = "value";
+
+  /** Constructor
+   * @param init - the specification for the ValuePropDef
+   */
+  constructor(init: ValuePropSpec) {
+    super(init);
+  }
+
+  override textForValue(value: unknown) {
+    return value === undefined ? undefined : stringify(value);
+  }
+}
+
+/** A PropDef representing a single (possibly absent) vocab URI
+ */
+export class VocabPropDef extends CommonPropDef implements VocabPropSpec {
+  /** The type specifier */
+  readonly type = "vocab";
+
+  /** The (abbreviated) vocabulary URI */
+  readonly uri: string;
+
+  /** Constructor
+   * @param init - the specification for the VocabPropDef
+   * @param vocab - the localised vocab definitions to use
+   */
+  constructor(
+    init: VocabPropSpec,
+    readonly vocab: VocabDef,
+  ) {
+    super(init);
+    this.uri = init.uri;
+  }
+
+  override textForValue(value: unknown) {
+    if (typeof value === "string") return this.vocab.terms[value];
+    return "";
+  }
+}
+
+/** A PropDef representing zero or more single-valued PropDefs
+ */
+export class MultiPropDef extends CommonPropDef implements MultiPropSpec {
+  readonly type = "multi";
+  readonly of: InnerDef;
+
+  /** This indicates the vocab URI in use if it contains vocab Qname. It is
+   * undefined otherwise
+   */
+  readonly uri?: string;
+
+  /** This indicates the vocab definition in use if it contains vocab values. It is
+   * undefined otherwise
+   */
+  readonly vocab?: VocabDef;
+
+  /** Constructor
+   *
+   * @param init - the specification for this MultiPropSpec. Note, we insist on
+   * the of: parameter to be concrete so we can delegate getTextForProperty
+   * calls to it.
+   */
+  constructor(init: Omit<MultiPropSpec, "of"> & { of: InnerDef }) {
+    super(init);
+    this.of = init.of;
+
+    // Initialise the vocab if present
+    if ("vocab" in init.of) this.vocab = init.of.vocab;
+  }
+
+  override textForValue(value: unknown) {
+    if (value instanceof Array)
+      return value.map((v) => stringify(this.of.textForValue(v)));
+    return [];
+  }
+}
+
+/** A collection of named PropDefs */
+export type PropDefs = Record<string, PropDef>;

--- a/libs/common/src/prop-specs.ts
+++ b/libs/common/src/prop-specs.ts
@@ -1,0 +1,119 @@
+import { Dictionary } from "./common-types.js";
+
+/** Definitions of property specifiers, which can be instantiated as property
+ * definitions.
+ *
+ * i.e. A PropSpec instance can be used to instantiate an equivalent PropDef
+ * instance.  The former is an instance of interface, the latter a instance of a
+ * class, which comes with some logic for computing things that the PropSpec
+ * doesn't.
+ */
+
+/** This filter specifier for in PropSpecs */
+export interface FilterSpec {
+  /** Discriminator that needs to be present to distinguish empt
+   * objects from a filter spec */
+  preset: true;
+  /** The value to preset the filter to. Should be a valid value for the property,
+   * but if set to an invalid value, this is equivalent to no filter preset */
+  to?: unknown;
+}
+
+/** Defines the shared properties of all PropSpecs. */
+export interface CommonPropSpec {
+  /** Which property/field/header to initialise this property from.
+   *
+   * Useful when importing from external data, e.g. CSVs.
+   * If not set, defaults to the one with the same name.
+   */
+  from?: string;
+
+  /** What to call this property in the UI.
+   *
+   * Should be an existing (possibly abbreviated) vocab URI - the
+   * corresponding localised term will be used as the title.
+   *
+   * If undefined, the title defaults to the property's localised
+   * vocab title (if the property *is* a vocab property). Otherwise, the
+   * property ID is used verbatim, as a fallback. Note that a vocab
+   * title is *not* a good choice if more than one property shares the
+   * same vocab!
+   */
+  titleUri?: string;
+
+  /** Defines the filtering on this property, if present. Can be set to one of:
+   * - false or undefined: don't filter on this property
+   * - true: enable filter in UI, but don't pre-set it
+   * - a FilterSpec value: enable filter in UI and pre-set it to the value in `on`
+   *
+   * Aside: This design attempts to leave the possibility open for presetting
+   * the filter for non-vocab properties, even though that isn't currently
+   * implemented. These could contain an arbitrary value, and possibly an array
+   * thereof. Which means we need to allow the preset to match any value (or
+   * even an array of values). Therefore, to allow for that, we use the
+   * FilterSpec interface to distinguish a simple directive to "filter this
+   * property", from one with a preset, and which includes a `to` property that
+   * can be anything it might be set to.
+   *
+   * In the case of a vocab property, a uri string or (equivalently) a qname
+   * should be used. Althoug nin the latter case the prefix should be consistent
+   * with those in the data.
+   *
+   * Setting a prefix with an `on` value which has no matches, or cannot
+   * possibly have matches because it is not a valid value, will
+   * result in the filter default being ineffective - as it it weren't
+   * present. If it can be detected, there may be a warning.
+   */
+  filter?: FilterSpec | boolean;
+
+  /** Enables or disables the text searching on this property, if present.
+   */
+  search?: boolean;
+}
+
+/** The part of a property specifier that is meaningfully inside a multiple.
+ *
+ * InnerSpecs define value constraints, but not PropSpec-related information.
+ * This is so that a MultiPropSpec can wrap the value constrains without
+ * duplicating the PropSpec information redundantly.
+ */
+export type InnerPropSpec = InnerValuePropSpec | InnerVocabPropSpec;
+
+/** The shared part of ValueSpec and a MultiPropSpec of ValueSpecs */
+export type InnerValuePropSpec = {
+  /** The type specifier */
+  type: "value";
+  /** Optional indicator of how to interpret the text */
+  as?: "string" | "boolean" | "number";
+  /** Optional indicator of whether to be strict in interpretations */
+  strict?: boolean;
+};
+
+/** The hared part of a VocabSpec and a MultiPropSpec of VocabSpecs */
+export type InnerVocabPropSpec = {
+  /** The type specifier */
+  type: "vocab";
+  /** The (abbreviated) vocab term URI */
+  uri: string;
+};
+
+/** PropSpecs define properties of data items and how they map from raw objects */
+export type PropSpec = ValuePropSpec | VocabPropSpec | MultiPropSpec;
+
+/** A PropSpec representing a single (possibly absent) text value. */
+export type ValuePropSpec = CommonPropSpec & InnerValuePropSpec;
+
+/** A PropSpec representing a single (possibly absent) vocab URI. */
+export type VocabPropSpec = CommonPropSpec & InnerVocabPropSpec;
+
+/** A PropSpec representing zero or more InnerPropSpecs */
+export type MultiPropSpec = CommonPropSpec & {
+  type: "multi";
+  of: InnerPropSpec;
+};
+
+/** The any of the possible PropSpec type specifiers */
+export type PropSpecType = PropSpec["type"];
+
+/** A collection of named PropSpecs. */
+export type PropSpecs = Dictionary<PropSpec>;

--- a/libs/common/src/rxdefs.ts
+++ b/libs/common/src/rxdefs.ts
@@ -60,6 +60,15 @@ export const NCName =
  */
 export const QName = new RegExp(`${NCName.source}[:]${NCName.source}`, "imsu");
 
+/** Match an AbbrevUri
+ *
+ * An abbreviated URI. This is essentially a QName without the second NCName.
+ *
+ * It represent a pre-defined URI base using the abbreviated name, followed by a
+ * colon.
+ */
+export const AbbrevUri = new RegExp(`${NCName.source}[:]`, "imsu");
+
 /** A Prefix-URI scheme.
  *
  * Note, limited to http and https.

--- a/libs/common/src/text-search.ts
+++ b/libs/common/src/text-search.ts
@@ -1,0 +1,26 @@
+/** NOTE - this is a cut-down excerpt from Mykomap 3.x's state-manager.ts
+ * code.  We don't currently need the rest of it. But if we do recover the rest,
+ * this should probably be merged back into that.
+ * One difference to note also: this lower-cases, rather than upper-cases.
+ */
+
+/** Text search utilities */
+export class TextSearch {
+  /** Normalises a text string into an indexable form.
+   *
+   * Performs these steps:
+   * - Lower-cases it
+   * - Eliminates non word-breaking punctuation (`\`'`)
+   * - Converts all other punctuation to space characters.
+   * - Deduplicates whitespace
+   * - Trims whitespace from front and back of the string.
+   */
+  static normalise(text: string): string {
+    return text
+      .toLowerCase()
+      .replace(/['`]/, "") // eliminate non word-breaking punctuation
+      .replace(/[^\w ]+/g, " ") // all other punctuation to space
+      .replace(/\s+/g, " ") // deduplicate whitespace
+      .trim(); // trim whitespace from front and back
+  }
+}

--- a/libs/common/src/utils.ts
+++ b/libs/common/src/utils.ts
@@ -1,0 +1,295 @@
+import { Box2d, Point2d } from "./common-types.js";
+
+/** A function which aggregates an array of numbers (or null/undefined) into a
+ * single number. */
+export type numberAryFn = (
+  array: Array<number | undefined | null>,
+) => number | undefined;
+
+/** Returns the largest of an array if numbers - non-numbers get converted to
+ * negative infinity. */
+export const arrayMax: numberAryFn = (ary) =>
+  ary.reduce<number | undefined>((a, b) => highest(a, b), undefined);
+
+/** Returns the smallest of an array if numbers - non-numbers get converted to positive infinity. */
+export const arrayMin: numberAryFn = (ary) =>
+  ary.reduce<number | undefined>((a, b) => lowest(a, b), undefined);
+
+/** Predicate which checks whether x is a booleans */
+export const isBool = (x: unknown): x is boolean => typeof x === "boolean";
+
+/** Predicate which checks whether x is a string */
+export const isString = (x: unknown): x is string => typeof x === "string";
+
+/** Converts anything not an actual string into the default value y (which
+ * itself defaults to the empty string) */
+export const stringify = <T = string>(
+  x: unknown,
+  y: T | string = "",
+): string | T => (typeof x === "string" ? x : y);
+
+/** Removes any NaN value from x, replaces it with a default value y (which
+ * itself defaults to 0) */
+export const toYesANumber = <T = number>(x: number, y: T | number = 0) =>
+  isNaN(x) ? y : x;
+
+/** Predicate which checks whether x is a number */
+export const isNumber = (x: unknown): x is number => typeof x === "number";
+
+/** Predicate which checks whether x is a number */
+export const yesANumber = (x: unknown): x is number =>
+  typeof x === "number" && !isNaN(x);
+
+/** Converts anything not an actual number (including NaNs) into
+ * the default value y (which itself defaults to 0) */
+export function numberify<T = number>(
+  x: unknown,
+  y: T | number = 0,
+): number | T {
+  switch (typeof x) {
+    case "number":
+      return toYesANumber(x, y);
+    case "string":
+      return toYesANumber(Number.parseFloat(x), y);
+    default:
+      return y;
+  }
+}
+
+/** Strictly checks whether the parameter is a 2-element array of two numbers
+ * (which are not NaN)
+ */
+export function isPoint2d(x: unknown): x is Point2d {
+  if (!(x instanceof Array)) return false;
+  if (x.length < 2) return false;
+  if (x.length !== 2) return false;
+  if (typeof x[0] !== "number" || isNaN(x[0])) return false;
+  if (typeof x[1] !== "number" || isNaN(x[1])) return false;
+  return true;
+}
+
+/** Converts anything not an actual (or approximate) Point2d into the default value y (which itself defaults to [0,0])
+ *
+ * We assume most inputs will be valid, and attempt to return valid values unchanged, as fast as possible.
+ * Nearly Point2d values will be converted to full Point2d. So,
+ * - extra elements will be dropped
+ * - an object which looks like an array with elements 0 and 1 will be converted
+ * - reasonable attempts to convert string values to numbers will be made
+ * - nulls and undefined values are not accepted.
+ * - NaNs are not accepted.
+ */
+export function toPoint2d<T = Point2d>(
+  x: unknown,
+  y: T | Point2d = [0, 0],
+): Point2d | T {
+  if (x instanceof Array) {
+    if (x.length == 2) {
+      if (typeof x[0] === "number" && typeof x[1] === "number")
+        return x as Point2d; // unchanged, just validated
+    }
+    if (x.length < 2) return y;
+    const p0 = numberify(x[0], null);
+    const p1 = numberify(x[1], null);
+    if (typeof p0 === "number" && typeof p1 === "number") return [p0, p1]; // rescue arrays of >= 2 numbers or strings which are numbers
+    return y; // No dice
+  }
+  if (x instanceof Object) {
+    if ("0" in x && "1" in x) {
+      const p0 = numberify(x[0], null);
+      const p1 = numberify(x[1], null);
+      if (typeof p0 === "number" && typeof p1 === "number") return [p0, p1]; // rescue array-like objects with elements 0 and 1 which are numbers or strings which are numbers
+    }
+    return y; // No dice
+  }
+  return y; // No dice
+}
+
+/** Strictly checks whether the parameter is a 2-element array of two Point2d items. */
+export function isBox2d(x: unknown): x is Box2d {
+  if (!(x instanceof Array)) return false;
+  if (x.length < 2) return false;
+  if (x.length !== 2) return false;
+  if (!isPoint2d(x[0])) return false;
+  if (!isPoint2d(x[1])) return false;
+  return true;
+}
+
+/** Checks thast the box has all finite numbers */
+export function isFiniteBox2d(x: Box2d): boolean {
+  return (
+    Number.isFinite(x[0][0]) &&
+    Number.isFinite(x[0][1]) &&
+    Number.isFinite(x[1][0]) &&
+    Number.isFinite(x[1][1])
+  );
+}
+
+/** Converts anything not an actual (or approximate) Box2d into the
+ * default value y (which itself defaults to [0,0])
+ *
+ * We assume most inputs will be valid, and attempt to return
+ * valid values unchanged, as fast as possible.
+ *
+ * Nearly Box2d values will be converted to full Box2d. So,
+ * - extra elements will be dropped
+ * - an object which looks like an array with elements 0 and 1 will be converted
+ * - reasonable attempts to convert string values to numbers will be made
+ * - nulls and undefined values are not accepted.
+ * - NaNs are not accepted.
+ */
+export function toBox2d<T = Box2d>(
+  x: unknown,
+  y: Box2d | T = [
+    [0, 0],
+    [0, 0],
+  ],
+): Box2d | T {
+  if (x instanceof Array) {
+    if (x.length >= 2) {
+      if (isPoint2d(x[0]) && isPoint2d(x[1])) {
+        if (x.length === 2) return x as Box2d; // Exactly right, return as is.
+
+        // If we get here, it's got extra elements.  Chop them off.
+        return [x[0], x[1]] as Box2d;
+      }
+
+      // If we get here, the first two elements aren't Point2ds
+      // so attempt to convert them.
+      const b1 = toPoint2d(x[0], null);
+      const b2 = toPoint2d(x[0], null);
+
+      if (b1 && b2) return [b1, b2];
+    }
+  }
+  return y;
+}
+
+/** Returns the union of two Box2ds.
+ *
+ * If only one is defined, returns that. If neither are, returns undefined.
+ */
+export function box2dUnion(a?: Box2d, b?: Box2d): Box2d | undefined {
+  if (a) {
+    if (b)
+      return [
+        [
+          Math.min(a[0][0], a[1][0], b[0][0], b[1][0]),
+          Math.min(a[0][1], a[1][1], b[0][1], b[1][1]),
+        ],
+        [
+          Math.max(a[0][0], a[1][0], b[0][0], b[1][0]),
+          Math.max(a[0][1], a[1][1], b[0][1], b[1][1]),
+        ],
+      ];
+    // Combine both
+    else return a; // Just a
+  } else {
+    if (b)
+      return b; // Just b
+    else return undefined; // Neither
+  }
+}
+
+/** Returns the highest of two numbers, or undefined if they are both undefined/null.
+ *
+ * If only one is defined, returns that.
+ *
+ * Note - Math.min cannot handle nulls/undefined correctly (it converts to 0!)
+ */
+export function lowest(
+  x?: number | null,
+  y?: number | null,
+): number | undefined {
+  if (x == null) {
+    // == null matches undefined
+    if (y == null) return undefined;
+    else return y;
+  }
+  if (y == null) return x;
+  return x < y ? x : y;
+}
+
+/** Returns the lowest of two numbers, or undefined if they are both undefined/null.
+ *
+ * If only one is defined, returns that.
+ *
+ * Note - Math.min cannot handle nulls/undefined correctly (it converts to 0!)
+ */
+export function highest(
+  x?: number | null,
+  y?: number | null,
+): number | undefined {
+  if (x == null) {
+    // == null matches undefined
+    if (y == null) return undefined;
+    else return y;
+  }
+  if (y == null) return x;
+  return x > y ? x : y;
+}
+
+/** Converts two arrays of x and y coordinates into a Box2d encompassing the range
+ *
+ * The box will span the range of x and y coordinates.  However, if
+ * either access has no span, an undefined value is returned.
+ */
+export function arrays2Box2d(
+  x: Array<number | undefined | null>,
+  y: Array<number | undefined | null>,
+): Box2d | undefined {
+  let minx: number | undefined = arrayMin(x);
+  if (minx === undefined) return undefined;
+
+  let miny: number | undefined = arrayMin(y);
+  if (miny === undefined) return undefined;
+
+  let maxx: number | undefined = arrayMax(x);
+  if (maxx === undefined) return undefined;
+
+  let maxy: number | undefined = arrayMax(y);
+  if (maxy === undefined) return undefined;
+
+  return [
+    [minx, miny],
+    [maxx, maxy],
+  ];
+}
+
+/** Promote an unknown value into an array of unknowns
+ *
+ * Converting single values into an array if not already
+ */
+export function promoteToArray<T = unknown[]>(x: unknown): T | unknown[] {
+  if (x instanceof Array) return x;
+  if (x == null)
+    // or undefined
+    return [];
+  return [x];
+}
+
+/** Compact an array (or an empty reference) of possibly undefined values into
+ * an array with no undefined values
+ */
+export function compactArray<T>(
+  x: (T | undefined | null)[] | undefined | null,
+): T[] {
+  if (!x) return [];
+  return x.filter((it): it is T => it !== undefined);
+}
+
+/** Throw an error with the given message if the expression is not truthy */
+export function assert(expr: unknown, msg?: string): asserts expr {
+  if (!expr) throw new Error(msg);
+}
+
+/** Predicate function, i.e. one which returns a boolean */
+export type Predicate<T> = (it: T) => boolean;
+
+/** Filters a Set with a predicate, returning a new Set. */
+export function filterSet<T>(set: Set<T>, predicate: Predicate<T>): Set<T> {
+  const result = new Set<T>();
+  set.forEach((item) => {
+    if (predicate(item)) result.add(item);
+  });
+  return result;
+}

--- a/libs/common/src/utils.ts
+++ b/libs/common/src/utils.ts
@@ -78,10 +78,11 @@ export function isPoint2d(x: unknown): x is Point2d {
  * - nulls and undefined values are not accepted.
  * - NaNs are not accepted.
  */
-export function toPoint2d<T = Point2d>(
-  x: unknown,
-  y: T | Point2d = [0, 0],
-): Point2d | T {
+
+export function toPoint2d(x: unknown, y: null): Point2d | null;
+export function toPoint2d(x: unknown, y?: undefined): Point2d | undefined;
+export function toPoint2d<T = Point2d>(x: unknown, y: T): Point2d | T;
+export function toPoint2d<T = Point2d>(x: unknown, y: T): Point2d | T {
   if (x instanceof Array) {
     if (x.length == 2) {
       if (typeof x[0] === "number" && typeof x[1] === "number")
@@ -137,13 +138,10 @@ export function isFiniteBox2d(x: Box2d): boolean {
  * - nulls and undefined values are not accepted.
  * - NaNs are not accepted.
  */
-export function toBox2d<T = Box2d>(
-  x: unknown,
-  y: Box2d | T = [
-    [0, 0],
-    [0, 0],
-  ],
-): Box2d | T {
+export function toBox2d(x: unknown, y: null): Box2d | null;
+export function toBox2d(x: unknown, y?: undefined): Box2d | undefined;
+export function toBox2d<T = Box2d>(x: unknown, y: T): Box2d | T;
+export function toBox2d<T = Box2d>(x: unknown, y: T): Box2d | T {
   if (x instanceof Array) {
     if (x.length >= 2) {
       if (isPoint2d(x[0]) && isPoint2d(x[1])) {

--- a/libs/common/test/validation.test.ts
+++ b/libs/common/test/validation.test.ts
@@ -12,6 +12,7 @@ const {
   DatasetItemId,
   DatasetItemIx,
   DatasetItemIdOrIx,
+  AbbrevUri,
   QName,
   PrefixUri,
   Iso639Set1Code,
@@ -194,6 +195,31 @@ test("testing QName validation", async (t) => {
     "",
     ":",
     "a:",
+    ":a",
+    "_",
+    "-",
+    ".",
+    "&",
+    ";",
+    "/",
+    "1:",
+    ":1",
+    "a:1",
+    "1:a",
+    "-:-",
+  ]);
+});
+
+test("testing AbbrevUri validation", async (t) => {
+  expectValid(AbbrevUri, ["a:", "a1:", "_:", "_1-.:"]);
+  expectInvalid(AbbrevUri, [
+    "",
+    ":",
+    "a:b",
+    "a:_",
+    "a:1",
+    "a: ",
+    " a:",
     ":a",
     "_",
     "-",


### PR DESCRIPTION
#### What? Why?

Related to issue #30

The PropDefs are interfaces used in Mykomap 3.x to describe the properties (fields) of the data being mapped. We need a similar description to be able to manipulate data for the import script, and for the back-end search/filter implementation.

This PR just covers these definitions, plus logic for creating and manipulating them using equivalent classes, which are new.  The classes are called PropDefs, the old interfaces are renamed as PropSpecs.  Most of the ideas and logic remains the same, but the classes package the logic in a more convenient way and avoids the need for switch statements to handle the discriminator field. 

Corresponding Zod validators are added for inclusion of the PropSpecs in the ConfigData tupe, since inferring them from types seems (from research) not to be a feature which currently exists anywhere in a robustly implemented form.  This therefore means that configs now need a `itemProps` field, but that may be an empty object.

The ConfigData structure will be used to guide the imports of CSV data in an upcoming PR. This needs to allow the fields to be imported to vary depending on the CSV file, which will have a similar but varying set of fields depending on the source.

#### What should we test?

Tests should still pass. No new tests added here.
 
Zod validators have been tested in later commits to allow assignment of the result to PropSpec types.

#### Checklist

- N/A: Updated or added any necessary docs in `docs/`
- N/A: Added UTs - will be added later in import script PR
- [ ] Checked that all automated tests pass

