### PR TITLE
30 add prop defs to config part 2

### DIFF
--- a/apps/front-end/src/components/map/mapSlice.ts
+++ b/apps/front-end/src/components/map/mapSlice.ts
@@ -5,10 +5,10 @@ import { notNullish, schemas } from "@mykomap/common";
 import { z } from "zod";
 
 export type Location = z.infer<typeof schemas.Location>;
-export type Dataset = z.infer<typeof schemas.Dataset>;
+export type DatasetLocations = z.infer<typeof schemas.DatasetLocations>;
 
 export interface MapSliceState {
-  allLocations: Dataset;
+  allLocations: DatasetLocations;
   status: string;
 }
 
@@ -64,7 +64,7 @@ export const mapSlice = createAppSlice({
 // to re-form the features array every time the selector is called.
 // https://redux.js.org/usage/deriving-data-selectors#writing-memoized-selectors-with-reselect
 const selectAllFeatures = createSelector(
-  [(state): Dataset => state.map.allLocations],
+  [(state): DatasetLocations => state.map.allLocations],
   (allLocations): GeoJSON.Feature<GeoJSON.Point>[] =>
     allLocations
       .map((location, ix) => {

--- a/apps/front-end/src/components/map/mapSlice.ts
+++ b/apps/front-end/src/components/map/mapSlice.ts
@@ -1,14 +1,19 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { createAppSlice } from "../../app/createAppSlice";
 import { getDatasetLocations } from "../../services";
+import { notNullish, schemas } from "@mykomap/common";
+import { z } from "zod";
+
+export type Location = z.infer<typeof schemas.Location>;
+export type Dataset = z.infer<typeof schemas.Dataset>;
 
 export interface MapSliceState {
-  allLocations: number[][];
+  allLocations: Dataset;
   status: string;
 }
 
 const initialState: MapSliceState = {
-  allLocations: [[]],
+  allLocations: [],
   status: "loading",
 };
 
@@ -59,13 +64,19 @@ export const mapSlice = createAppSlice({
 // to re-form the features array every time the selector is called.
 // https://redux.js.org/usage/deriving-data-selectors#writing-memoized-selectors-with-reselect
 const selectAllFeatures = createSelector(
-  [(state): number[][] => state.map.allLocations],
+  [(state): Dataset => state.map.allLocations],
   (allLocations): GeoJSON.Feature<GeoJSON.Point>[] =>
-    allLocations.map((location, ix) => ({
-      type: "Feature",
-      geometry: { type: "Point", coordinates: location },
-      properties: { ix },
-    })),
+    allLocations
+      .map((location, ix) => {
+        if (!location) return null; // skip non-locations here to preserve index counting
+        const point: GeoJSON.Feature<GeoJSON.Point> = {
+          type: "Feature",
+          geometry: { type: "Point", coordinates: location },
+          properties: { ix },
+        };
+        return point;
+      })
+      .filter(notNullish),
 );
 
 /**

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -27,7 +27,7 @@ function ZodRegex(rx: RegExp, message: string) {
 const Location = z.array(z.number()).min(2).max(2);
 const DatasetId = z.string().regex(Rx.UrlSafeBase64);
 const DatasetItem = z.object({}).passthrough();
-const Dataset = z.array(Location);
+const Dataset = z.array(Location.nullable());
 const NCName = ZodRegex(Rx.NCName, "Invalid NCName format");
 const QName = ZodRegex(Rx.QName, "Invalid QName format");
 const DatasetItemId = ZodRegex(

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -27,7 +27,7 @@ function ZodRegex(rx: RegExp, message: string) {
 const Location = z.array(z.number()).min(2).max(2);
 const DatasetId = z.string().regex(Rx.UrlSafeBase64);
 const DatasetItem = z.object({}).passthrough();
-const Dataset = z.array(Location.nullable());
+const DatasetLocations = z.array(Location.nullable());
 const NCName = ZodRegex(Rx.NCName, "Invalid NCName format");
 const QName = ZodRegex(Rx.QName, "Invalid QName format");
 const DatasetItemId = ZodRegex(
@@ -117,7 +117,7 @@ export const schemas = {
   DatasetItemIdOrIx,
   DatasetItemIx,
   DatasetItem,
-  Dataset,
+  DatasetLocations,
   FilterSpec,
   I18nVocabDefs,
   Iso639Set1Code,
@@ -149,7 +149,7 @@ export const contract = c.router({
       }),
     }),
     responses: {
-      200: Dataset.openapi({
+      200: DatasetLocations.openapi({
         // description: "the dataset matching the supplied ID",
       }),
       400: ErrorInfo.openapi({

--- a/libs/common/src/api/mykomap-openapi.json
+++ b/libs/common/src/api/mykomap-openapi.json
@@ -31,7 +31,8 @@
                       "type": "number"
                     },
                     "minItems": 2,
-                    "maxItems": 2
+                    "maxItems": 2,
+                    "nullable": true
                   }
                 }
               }

--- a/libs/common/src/prop-defs.ts
+++ b/libs/common/src/prop-defs.ts
@@ -168,11 +168,17 @@ export class ValuePropDef extends CommonPropDef implements ValuePropSpec {
   /** The type specifier */
   readonly type = "value";
 
+  /** Conversion hints */
+  readonly as: ValuePropSpec["as"];
+  readonly strict: ValuePropSpec["strict"];
+
   /** Constructor
    * @param init - the specification for the ValuePropDef
    */
   constructor(init: ValuePropSpec) {
     super(init);
+    this.as = init.as;
+    this.strict = init.strict;
   }
 
   override textForValue(value: unknown) {

--- a/libs/common/src/prop-defs.ts
+++ b/libs/common/src/prop-defs.ts
@@ -20,11 +20,11 @@ import { schemas } from "./api/contract.js";
 import { z } from "zod";
 
 // Infer the types of various contract values....
-type VocabDef = z.infer<typeof schemas.VocabDef>;
-type I18nVocabDefs = z.infer<typeof schemas.I18nVocabDefs>;
-type VocabIndex = z.infer<typeof schemas.VocabIndex>;
-type Iso639Set1Code = z.infer<typeof schemas.Iso639Set1Code>;
-type NCName = z.infer<typeof schemas.NCName>;
+export type VocabDef = z.infer<typeof schemas.VocabDef>;
+export type I18nVocabDefs = z.infer<typeof schemas.I18nVocabDefs>;
+export type VocabIndex = z.infer<typeof schemas.VocabIndex>;
+export type Iso639Set1Code = z.infer<typeof schemas.Iso639Set1Code>;
+export type NCName = z.infer<typeof schemas.NCName>;
 
 /** The part of a property definition that is meaningfully inside a multiple */
 export type InnerDef = VocabPropDef | ValuePropDef;

--- a/libs/common/src/utils.ts
+++ b/libs/common/src/utils.ts
@@ -33,10 +33,10 @@ export const stringify = <T = string>(
 export const toYesANumber = <T = number>(x: number, y: T | number = 0) =>
   isNaN(x) ? y : x;
 
-/** Predicate which checks whether x is a number */
+/** Predicate which checks whether x is a number (including NaN) */
 export const isNumber = (x: unknown): x is number => typeof x === "number";
 
-/** Predicate which checks whether x is a number */
+/** Predicate which checks whether x is a number (excluding NaN) */
 export const yesANumber = (x: unknown): x is number =>
   typeof x === "number" && !isNaN(x);
 

--- a/libs/common/src/utils.ts
+++ b/libs/common/src/utils.ts
@@ -265,6 +265,14 @@ export function promoteToArray<T = unknown[]>(x: unknown): T | unknown[] {
   return [x];
 }
 
+/** Helper function to exlcude undefined values in filter operations */
+export const notUndefined = <T>(it: T): it is Exclude<T, undefined> =>
+  it !== undefined;
+
+/** Helper function to exclude nullish values in filter operations */
+export const notNullish = <T>(it: T): it is Exclude<T, null | undefined> =>
+  it != null;
+
 /** Compact an array (or an empty reference) of possibly undefined values into
  * an array with no undefined values
  */
@@ -272,7 +280,7 @@ export function compactArray<T>(
   x: (T | undefined | null)[] | undefined | null,
 ): T[] {
   if (!x) return [];
-  return x.filter((it): it is T => it !== undefined);
+  return x.filter(notNullish);
 }
 
 /** Throw an error with the given message if the expression is not truthy */


### PR DESCRIPTION
#### What? Why?

Related to issue #30

Some further alterations necessary for the upcoming final PR for issue #30 which implements the dataset importer.
- The Location Zod validator must permit null locations
- Export the inferred types from the contracts, so they can be used.
- some properties (`strict`, `as`) were not captured by the PropDef constructor
- a jsdoc clarification and openapi regeneration


#### What should we test?

Tests should all pass as before. 

#### Checklist

- N/A] Updated or added any necessary docs in `docs/`
- N/A Added UTs
- [ ] Checked that all automated tests pass

