### PR TITLE
[back-end] Add Glitchtip error tracking

### DIFF
--- a/apps/back-end/package.json
+++ b/apps/back-end/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^9.0.1",
+    "@immobiliarelabs/fastify-sentry": "^8.0.2",
     "@mykomap/common": "*",
     "@mykomap/node-utils": "*",
     "@seriousme/openapi-schema-validator": "^2.2.1",

--- a/apps/back-end/src/errors.ts
+++ b/apps/back-end/src/errors.ts
@@ -1,0 +1,7 @@
+export class HttpError extends Error {
+  statusCode: number;
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}

--- a/apps/back-end/src/routes.ts
+++ b/apps/back-end/src/routes.ts
@@ -1,4 +1,3 @@
-import { TsRestResponseError } from "@ts-rest/core";
 import { RouterImplementation } from "@ts-rest/fastify";
 import { contract } from "@mykomap/common";
 import { FastifyPluginOptions } from "fastify";
@@ -11,6 +10,7 @@ import {
   initDatasets,
   searchDataset,
 } from "./services/datasetService.js";
+import { HttpError } from "./errors.js";
 
 /** Provides the shared configuration options for the Mykomap router implementation. */
 export interface MykomapRouterConfig extends FastifyPluginOptions {
@@ -92,10 +92,7 @@ export function MykomapRouter(
       // assume it is an Index.
       // TODO: extend this method to handle full IDs too
       if (!datasetItemIdOrIx.startsWith("@")) {
-        throw new TsRestResponseError(contract.getDatasetItem, {
-          status: 400,
-          body: { message: `We can only handle item indexes right now` },
-        });
+        throw new HttpError(400, `We can only handle item indexes right now`);
       }
 
       const itemIx = Number(datasetItemIdOrIx.substring(1));

--- a/apps/back-end/src/services/datasetService.ts
+++ b/apps/back-end/src/services/datasetService.ts
@@ -1,13 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import {
-  AppRoute,
-  ServerInferResponseBody,
-  TsRestResponseError,
-} from "@ts-rest/core";
+import { AppRoute, ServerInferResponseBody } from "@ts-rest/core";
 
 import { contract } from "@mykomap/common";
 import { Dataset } from "./Dataset.js";
+import { HttpError } from "../errors.js";
 
 type GetConfigBody = ServerInferResponseBody<typeof contract.getConfig, 200>;
 type SearchDatasetBody = ServerInferResponseBody<
@@ -40,11 +37,7 @@ const getDatasetOrThrow404 = (
 ): Dataset => {
   const dataset = datasets[datasetId];
 
-  if (!dataset)
-    throw new TsRestResponseError(appRoute, {
-      status: 404,
-      body: { message: `dataset ${datasetId} doesn't exist` },
-    });
+  if (!dataset) throw new HttpError(404, `dataset ${datasetId} doesn't exist`);
 
   return dataset;
 };

--- a/apps/front-end/.env.example
+++ b/apps/front-end/.env.example
@@ -1,3 +1,3 @@
 VITE_API_URL=replace-me
-VITE_GLITCHTIP_KEY=replace-me
+VITE_GLITCHTIP_KEY=dont-use-on-development
 VITE_MAPTILER_API_KEY=replace-me

--- a/apps/front-end/.env.example
+++ b/apps/front-end/.env.example
@@ -1,3 +1,2 @@
 VITE_API_URL=replace-me
-VITE_GLITCHTIP_KEY=dont-use-on-development
 VITE_MAPTILER_API_KEY=replace-me

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,7 +21,8 @@ set -vx
 #   - PROXY_PORT: the port number being proxied (e.g. '4000')
 #   - PROXY_PATH: the path being proxied (e.g. '/api')
 #   - BASE_URL_PATH # not actually used but might be in future?
-#   - GLITCHTIP_KEY
+#   - FE_GLITCHTIP_KEY
+#   - BE_GLITCHTIP_KEY
 #   - MAPTILER_API_KEY
 #   - DBUS_SESSION_BUS_ADDRESS: required for service management
 # - FIXME the user can write to DEPLOY_DEST, WWW_ROOT
@@ -84,7 +85,7 @@ cp .tool-versions "$DEPLOY_DEST"
   # FIXME these shouldn't be hardwired!
   cat >>.env <<EOF
 VITE_API_URL=/api
-VITE_GLITCHTIP_KEY=${GLITCHTIP_KEY:?}
+VITE_GLITCHTIP_KEY=${FE_GLITCHTIP_KEY:?}
 VITE_MAPTILER_API_KEY=${MAPTILER_API_KEY:?}
 EOF
   
@@ -105,6 +106,7 @@ EOF
   cat >>"$BE_DEST/.env" <<EOF
 SERVER_DATA_ROOT=$DATA_DEST
 FASTIFY_PORT=$PROXY_PORT
+GLITCHTIP_KEY=${BE_GLITCHTIP_KEY:?}
 #   root address?
 EOF
   

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,7 +76,8 @@ values redacted:
     export PROXY_PORT=1$UID
     export PROXY_PATH=/api
     export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$UID/bus
-    export GLITCHTIP_KEY=*REDACTED*
+    export FE_GLITCHTIP_KEY=*REDACTED*
+    export BE_GLITCHTIP_KEY=*REDACTED*
     export MAPTILER_API_KEY=*REDACTED*
 
 *Note: paths here should be absolute - relative paths will not work in

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "version": "4.0.0",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
+        "@immobiliarelabs/fastify-sentry": "^8.0.2",
         "@mykomap/common": "*",
         "@mykomap/node-utils": "*",
         "@seriousme/openapi-schema-validator": "^2.2.1",
@@ -3811,6 +3812,43 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@immobiliarelabs/fastify-sentry": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@immobiliarelabs/fastify-sentry/-/fastify-sentry-8.0.2.tgz",
+      "integrity": "sha512-GxCIVYJIO3gtskVK9WGSmKjaCmzsv0RNaNegWebXf97d/MIq3a5FsFmyXaVANLwPfO/c2FuScECx0TbSdKeBfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/node": "^7.105.0",
+        "@sentry/tracing": "^7.105.0",
+        "@sentry/utils": "^7.105.0",
+        "cookie": "^0.7.0",
+        "fastify-plugin": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@immobiliarelabs/fastify-sentry/node_modules/@sentry/types": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@immobiliarelabs/fastify-sentry/node_modules/@sentry/utils": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@inquirer/confirm": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.0.2.tgz",
@@ -5418,6 +5456,54 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/core": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sentry/browser": {
       "version": "8.33.1",
       "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.33.1.tgz",
@@ -5447,6 +5533,165 @@
       },
       "engines": {
         "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/core": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/types": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations/node_modules/@sentry/utils": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.120.0.tgz",
+      "integrity": "sha512-GAyuNd8WUznsiOyDq2QUwR/aVnMmItUc4tgZQxhH1R+n4Adx3cAhnpq3zEuzsIAC5+/7ut+4Q4B3akh6SDZd4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.114.0.tgz",
+      "integrity": "sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry-internal/tracing": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.114.0.tgz",
+      "integrity": "sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.114.0",
+        "@sentry/types": "7.114.0",
+        "@sentry/utils": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/core": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.114.0.tgz",
+      "integrity": "sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.114.0",
+        "@sentry/utils": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/types": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.114.0.tgz",
+      "integrity": "sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/@sentry/utils": {
+      "version": "7.114.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.114.0.tgz",
+      "integrity": "sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "7.114.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/types": {
@@ -9030,7 +9275,6 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12324,6 +12568,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/immer": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
@@ -13373,6 +13623,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/light-my-request": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.14.0.tgz",
@@ -13424,6 +13683,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {


### PR DESCRIPTION
#### What? Why?

This will allow us to track uncaught exceptions and also 4xx and 5xx HTTP errors, viewable on the Glitchtip dashboard https://app.glitchtip.com/digital-commons-coop/issues?project=9203

(I included 4xx errors since we shouldn't really be hitting these if the FE is supplying the correct data)

It would be nice to notify Element devops channel but doesn't look like Glitchtip supports this yet. We could probably get it working eventually though, with some sort of workaround using webhooks or Matrix bots.

I've tested that this works on my local machine and the events are being picked up on the Glitchtip console

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->

Need to change `export GLITCHTIP_KEY=<key>` in the deploy.env to `export FE_GLITCHTIP_KEY=<key>;export BE_GLITCHTIP_KEY=<key>;` when deploying to the servers.