### PR TITLE
Fix `npm run start` in back-end app

### DIFF
--- a/apps/back-end/src/index.ts
+++ b/apps/back-end/src/index.ts
@@ -1,6 +1,6 @@
 import fastifySentryPlugin from "@immobiliarelabs/fastify-sentry";
 import closeWithGrace from "close-with-grace";
-import Fastify from "fastify";
+import { FastifyListenOptions, fastify } from "fastify";
 import cors from "@fastify/cors";
 import qs from "qs";
 import apiPlugin from "./pluginApi.js";
@@ -9,25 +9,41 @@ export { apiPlugin }; // For use as a library
 // Something is weird about udsv, we can't import nor export Schema directly and
 // seem to have to do this...
 import udsv from "udsv";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
 export type Schema = ReturnType<typeof udsv.inferSchema>;
 
-// Set the number of milliseconds required for a graceful close to complete
-const closeGraceDelay = Number(process.env.FASTIFY_CLOSE_GRACE_DELAY) || 500;
-
-// Define the origin(s) for the purposes of CORS.
-// This environment variable will be interpreted as a space-delimited list of
-// URLs, which the Access-Control-Allow-Origin CORS header should allow.
-// @fastify/cors will add an onRequest hook and a wildcard options route for this.
-const corsOrigin = process.env.FASTIFY_CORS_ORIGIN?.split(/\s+/) || [];
-
-// The TCP port to the webserver should listen on
-const listenPort = Number(process.env.FASTIFY_PORT) || 3000;
-
-// The API path prefix to set.
-const apiPathPrefix = process.env.API_PATH_PREFIX || "/";
-
-export const start = async () => {
-  const app = Fastify({
+// This class exists to encapsulate the process of starting the Mykomap server.
+//
+// The intention is that eveything a server needs is set in here, but also to
+// allow default parameters to be overridden, and extra plug-ins to be
+// registered, as we do need to in some scenarios. (Specifically, when run with
+// FastifyVite, that plug-in needs to be registered after the defaults have
+// been)
+//
+// Usage:
+//
+//     const launcher = new Launcher(); // creates the server
+//
+//     // Optionally alter the default paramters here.
+//
+//     await launcher.addDefaultPlugins(); // registers the default plugins
+//
+//     // Optionally, register any extra plugins we need here:
+//     launcher.app.register( /* ... */ );
+//
+//     const err = await launcher.start(); // start the server - should never return.
+//     process.exit(err == undefined? 1 : 0);
+//
+export class Launcher {
+  // The base Fasify server application.
+  //
+  // It has a logger and a querystringParser defined.
+  //
+  // Fastify types are a bit of a nightmare. We delilberately don't put a type
+  // here because the type is so complicated it seems impossible to express
+  // generally without type errors when you assign to it...
+  readonly app = fastify({
     logger: {
       level: process.env.NODE_ENV === "development" ? "debug" : "info",
     },
@@ -36,70 +52,121 @@ export const start = async () => {
     querystringParser: (str) => qs.parse(str),
   });
 
-  // The Sentry error handler must be the first plugin registered
-  if (process.env.GLITCHTIP_KEY) {
-    console.log("Initialising Sentry...");
-    app.register(fastifySentryPlugin, {
-      dsn: `https://${process.env.GLITCHTIP_KEY}@app.glitchtip.com/9203`,
-      environment: process.env.NODE_ENV,
-      release: __BUILD_INFO__.version.join("."),
-      // Capture all uncaught or HTTP 4xx and 5xx errors
-      // Note this doesn't work for TsRestResponseErrors since they skip this middleware
-      shouldHandleError: (error) =>
-        !error.statusCode || error.statusCode >= 400,
-    });
-  }
+  // Sets the number of milliseconds required for a graceful close to complete
+  closeGraceDelay = Number(process.env.FASTIFY_CLOSE_GRACE_DELAY) || 500;
 
-  // This closes the application with a delay to clear up.
-  closeWithGrace(
-    { delay: closeGraceDelay },
-    async ({ signal: _signal, err, manual: _manual }) => {
-      if (err) {
-        app?.log?.error(err);
-        console.error(err);
-      }
-      await app?.close();
-    },
-  );
+  // Defines the origin(s) for the purposes of CORS.
+  // This environment variable will be interpreted as a space-delimited list of
+  // URLs, which the Access-Control-Allow-Origin CORS header should allow.
+  // @fastify/cors will add an onRequest hook and a wildcard options route for this.
+  corsOrigin = process.env.FASTIFY_CORS_ORIGIN?.split(/\s+/) || [];
 
-  // This avoids EADDRINUSE errors caused when vite-node's HMR tries to
-  // restart the server when the old one is still running.
-  // https://github.com/vitest-dev/vitest/issues/2334
-  // @ts-ignore // seems  to be a bug in vite that this is not defined
-  if (import.meta.hot) {
-    // @ts-ignore
-    import.meta.hot.on("vite:beforeFullReload", () => {
-      console.log("Reload");
-      app.close();
-    });
-  }
+  // The TCP port to the webserver should listen on
+  listenPort = Number(process.env.FASTIFY_PORT) || 3000;
 
-  try {
-    // Register CORS plugin - this is primarily to allow the back end to
-    // be on a different host/port.
-    if (corsOrigin) {
-      console.log("Registering CORS at ", corsOrigin);
-      await app.register(cors, {
-        origin: corsOrigin,
+  // The API path prefix to set.
+  apiPathPrefix = process.env.API_PATH_PREFIX || "/";
+
+  // Where to load data from
+  dataRoot =
+    process.env.SERVER_DATA_ROOT ??
+    dirname(fileURLToPath(import.meta.resolve("@mykomap/back-end/test/data")));
+
+  // Constructs the ServerLauncher with a stock fastify instance.
+  constructor() {}
+
+  // Adds any default plugins we need.
+  //
+  // You should call this before calling listen() else the server will have
+  // no API plugin registered!
+  async addDefaultPlugins(): Promise<void> {
+    // The Sentry error handler must be the first plugin registered
+    if (process.env.GLITCHTIP_KEY) {
+      console.log("Initialising Sentry...");
+      await this.app.register(fastifySentryPlugin, {
+        dsn: `https://${process.env.GLITCHTIP_KEY}@app.glitchtip.com/9203`,
+        environment: process.env.NODE_ENV,
+        release: __BUILD_INFO__.version.join("."),
+        // Capture all uncaught or HTTP 4xx and 5xx errors
+        // Note this doesn't work for TsRestResponseErrors since they skip this middleware
+        shouldHandleError: (error) =>
+          !error.statusCode || error.statusCode >= 400,
       });
     }
 
-    // Mykomap API options
-    const opts = {
-      dataRoot: process.env.SERVER_DATA_ROOT ?? "test/data",
-    };
+    try {
+      // Register CORS plugin - this is primarily to allow the back end to
+      // be on a different host/port.
+      if (this.corsOrigin) {
+        console.log("Registering CORS at ", this.corsOrigin);
+        await this.app.register(cors, {
+          origin: this.corsOrigin,
+        });
+      }
 
-    // Register the API routes
-    await app.register(apiPlugin, {
-      mykomap: opts,
-      prefix: apiPathPrefix,
-      responseValidation: true,
-    });
+      // Mykomap API options
+      const opts = {
+        dataRoot: this.dataRoot,
+      };
+      console.info(`Using back-end data path: ${opts.dataRoot}`);
 
-    // Start listening
-    await app.listen({ port: listenPort });
-  } catch (err) {
-    app.log.error(err);
-    process.exit(1);
+      // Register the API routes
+      await this.app.register(apiPlugin, {
+        mykomap: opts,
+        prefix: this.apiPathPrefix,
+        responseValidation: true,
+      });
+    } catch (err) {
+      this.app.log.error(err);
+    }
   }
-};
+
+  // Start the server listening.
+  //
+  // Returns the result of this.app.listen(), or rethrows whatever was caught in
+  // the error block, after logging it.
+  async listen(
+    opts: FastifyListenOptions = { port: this.listenPort },
+  ): Promise<unknown> {
+    // This closes the application with a delay to clear up.
+    closeWithGrace(
+      { delay: this.closeGraceDelay },
+      async ({ signal: _signal, err, manual: _manual }) => {
+        if (err) {
+          this.app?.log?.error(err);
+          console.error(err);
+        }
+        await this.app?.close();
+      },
+    );
+
+    // This avoids EADDRINUSE errors caused when vite-node's HMR tries to
+    // restart the server when the old one is still running.
+    // https://github.com/vitest-dev/vitest/issues/2334
+    // @ts-ignore // seems  to be a bug in vite that this is not defined
+    if (import.meta.hot) {
+      // @ts-ignore
+      import.meta.hot.on("vite:beforeFullReload", () => {
+        console.log("Reload");
+        this.app.close();
+      });
+    }
+
+    try {
+      // Start listening
+      return await this.app.listen(opts);
+    } catch (err) {
+      this.app.log.error(err);
+      throw err;
+    }
+  }
+
+  // Shortcut method for starting the launcher.
+  //
+  // Creates a default Launcher, .addDefaultPlugins() it, then calls .listen()
+  static async start() {
+    const launcher = new Launcher();
+    await launcher.addDefaultPlugins();
+    await launcher.listen();
+  }
+}

--- a/apps/back-end/start.js
+++ b/apps/back-end/start.js
@@ -1,4 +1,4 @@
 // NOTE: Assumes server has been built already into dist/
-import { start } from "./dist/index.js";
+import { Launcher } from "./dist/index.js";
 
-start();
+Launcher.start();

--- a/apps/back-end/start.ts
+++ b/apps/back-end/start.ts
@@ -1,3 +1,3 @@
-import { start } from "./src/index";
+import { Launcher } from "./src/index";
 
-start();
+Launcher.start();

--- a/apps/front-end/server.ts
+++ b/apps/front-end/server.ts
@@ -1,35 +1,30 @@
-import Fastify from "fastify";
 import FastifyVite from "@fastify/vite";
-import { apiPlugin } from "@mykomap/back-end";
+import { Launcher } from "@mykomap/back-end";
 import { fileURLToPath } from "node:url";
 import { dirname } from "node:path";
 
-const logger = { level: process.env.SERVER_LOG_LEVEL };
-const server = Fastify({ logger });
 const root = dirname(fileURLToPath(import.meta.url));
 
-await server.register(FastifyVite, {
+// Create the basic Launcher instance
+const launcher = new Launcher();
+
+launcher.apiPathPrefix = "/api"; // Required when running in this mode
+
+// We always want these.
+await launcher.addDefaultPlugins();
+
+// Next, add the plugins needed to run with a Vite build server
+await launcher.app.register(FastifyVite, {
   root,
   // NOTE: if this isn't set true, things seem to break?
   dev: process.env.NODE_ENV === "development",
   spa: true,
 });
 
-// Mykomap API options
-const backEndTestData = dirname(
-  fileURLToPath(import.meta.resolve("@mykomap/back-end/test/data")),
-);
-const mykomap = {
-  dataRoot: process.env.SERVER_DATA_ROOT ?? backEndTestData,
-};
-console.info(`Using back-end data path: ${mykomap.dataRoot}`);
-
-server.register(apiPlugin, { mykomap, prefix: "/api" });
-
-server.get("/", (req, reply) => {
+// Set the default route to load the front end app
+await launcher.app.get("/", (req, reply) => {
   return reply.html();
 });
 
-await server.vite.ready();
-
-await server.listen({ port: 3000 });
+await launcher.app.vite.ready();
+await launcher.listen();


### PR DESCRIPTION
#### What? Why?

There is a run script in the MM front-end application's `package.json` called: `sta
rt`.

    npm run start

This should launch a server on http://localhost:3000 which has both front and back end integrated on the same URL, as it is in a production deployment. The front-end is accessible via the above URL, and the back-end via http://localhost:3000/api/.

Obviously it should work functionally identically to the live deployment. However it has not been: when viewing the directory, the listings for markers were not being shown, despite the total number of items being shown correctly.

This is a bug.

Note however, there is an alternative development process in which two processes are run:

    npm run dev # in the back end, listens on http://localhost:3000

And

    npm run dev # in the front end, listens on http://localhost:5173

This sets `VITE_API_URL=https://localhost:3000` in the environment of the front end to make it use the different back-end URL, and it requires the back-end to have CORS enabled to permit this to work.

This method is not exhibiting the bug. Nor are the production/development deploys on the server.

#### To replicate

To replicate:
- Check out the MM repository as normal, and `npm install` at the top level
- In `src/front-end` run `npm run start`
- Visit http://localhost:3000/?datasetId=dataset-A
- Check that there are some markers on the map - shoud be 4 of them.
- Open the side panel
- Click on "- any -"
- You should see the words "7 Matching results", but no items in the search results.

What should happen:
- As above, but all seven results should be shown

#### Code-specific details (for Reviewer)

Check that the code is readable and comprehensible.

#### Checklist

I'm not sure of a way to make a automated test for this. Nevertheless:

- [ ] Checked that all automated tests pass
- [ ] Check that the alternative method still works (see procedure above)

#### What should we test? (for QA)

Follow the replication procedure above. It should now give the expected outcome.