### PR TITLE
[front-end] mapLibre.ts - Enhance popup handling and cursor styling for spiderfied markers

### DIFF
--- a/apps/front-end/src/components/map/mapLibre.ts
+++ b/apps/front-end/src/components/map/mapLibre.ts
@@ -180,6 +180,17 @@ export const createMap = (
       ) => {
         const coordinates = feature.geometry.coordinates.slice();
         const itemIx = feature.properties?.ix;
+
+        if (popup?.isOpen() && popupIx === itemIx) {
+          console.log(
+            `Popup for item @${itemIx} already open so toggle closed`,
+          );
+          popup?.remove();
+          popupIx = undefined;
+          popup = undefined;
+          return;
+        }
+
         map
           .easeTo({
             center: [
@@ -205,6 +216,7 @@ export const createMap = (
       ) => {
         if (feature) {
           onMarkerHover(map, feature, leafOffset);
+          map.getCanvas().style.cursor = "pointer";
         } else {
           tooltip?.remove();
           map.getCanvas().style.cursor = "";
@@ -304,7 +316,7 @@ export const createMap = (
           ) as GeoJSON.Feature<GeoJSON.Point>;
 
       let zoom = 10; // start with this zoom, then hone in
-      let spiderfied = false // spiderfy when we get into the condition
+      let spiderfied = false; // spiderfy when we get into the condition
       const maxZoom = 18; // once we get to this zoom, stop
 
       const flyToThenOpenPopupRecursive = () => {
@@ -329,9 +341,9 @@ export const createMap = (
                   "Maybe the feature is in a cluster and needs to be spiderfied.",
                 );
                 // spiderfy the cluster
-                map.fire('click', {
-                  lngLat: location
-                })
+                map.fire("click", {
+                  lngLat: location,
+                });
 
                 if (!spiderfied) {
                   flyToThenOpenPopupRecursive();
@@ -419,6 +431,10 @@ export const createMap = (
     map.on("mouseleave", "unclustered-point", () => {
       tooltip?.remove();
       map.getCanvas().style.cursor = "";
+    });
+    // Cursor pointer on spiderfied cluster
+    map.on("mouseenter", "spiderfied-cluster", () => {
+      map.getCanvas().style.cursor = "pointer";
     });
 
     map.on("changeLanguage", ({ language }) => {


### PR DESCRIPTION
#### What? Why?

Related to issue #116

Markers connected to spiderfied clusters were not toggling their respective pop-ups. If a cluster was clicked the pop-up would open, if clicked again it would close and then immediately re-open. Expected behaviour being if a marker is clicked it should toggle its related pop-up either open or closed.

Related to issue #116

#### Code-specific details (for Reviewer)

Changes to the `createMap` function in the `apps/front-end/src/components/map/mapLibre.ts`, lines 184 -192 and 219

- Added logic to toggle the popup when it is already open for the same item, including logging and cleanup.
- Added an event listener to change the cursor to a pointer when hovering over a spiderfied cluster.

#### What should we test? (for QA)

- Navigate to location that contains multiple co-ops
- Click on the cluster
- Hover over a marker and ensure you see a pointer cursor
- Click on the marker to trigger the pop-up
- Click on the marker to ensure the pop-up closes and remains closed until toggled again

