### PR TITLE
Closing Results Panel Also Closes Directory/Search Panel - Fix

### DIFF
--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -12,8 +12,6 @@ import {
   selectPanelOpen,
   selectResultsPanelOpen,
   closeResultsPanel,
-  closePanel,
-  setSelectedTab,
 } from "../panelSlice";
 import { clearSearch } from "../searchPanel/searchSlice";
 import { useTranslation } from "react-i18next";

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -65,20 +65,14 @@ const ResultsPanel = () => {
 
   const handleToggle = () => {
     dispatch(togglePanel());
-    console.log("panelOpen", panelOpen);
   };
 
   const handlePanelClose = () => {
-    if (!isMedium) dispatch(setSelectedTab(0));
-    dispatch(closePanel());
     dispatch(closeResultsPanel());
     console.log("panelOpen", panelOpen);
   };
 
   const handleClearSearch = () => {
-    console.log("Clear search");
-    if (!isMedium) dispatch(setSelectedTab(0));
-    // dispatch(closePanel());
     dispatch(closeResultsPanel());
     dispatch(clearSearch());
   };


### PR DESCRIPTION
#### What? Why?

Closing the results panel on handheld devices, closes either the search panel or the directory panel, depending on the user journey. This requires the user to open the search / directory panel if they wish to continue searching. 

Related to issue #114

#### Code-specific details (for Reviewer)

Changes were made to the ResultsPanel component in apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx, `setSelectedTab` and `closePanel` were removed from the `handlePanelClose` and `handleClearSearch` event handlers.

#### Checklist

- Open CWM locally on a mobile device (or using dev tool, or browserStack)
- Open the search panel perform a search
- Clear your search from the results panel
- You should return to the search panel (cleared)
- Perform a second search
- Close the results panel using the close icon
- You should return to the search panel displaying you previous search
- Repeat the above for the directory panel
