### PR TITLE
115 cwm bug clear search feature is missing from search page

### DIFF
--- a/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
+++ b/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
@@ -25,6 +25,18 @@ interface ApplyFiltersProps {
 const ApplyFilters = ({buttonText, buttonAction, disabled}: ApplyFiltersProps) => {
   return (
     <StyledButtonContainer>
+      {!disabled && (
+        <StandardButton
+          variant="outlined"
+          buttonAction={() => {
+            buttonAction();
+          }}
+        >
+          
+        Reset Filters
+        </StandardButton>
+      )}
+     
       <StandardButton
         buttonAction={buttonAction}
         disabled={disabled}

--- a/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
+++ b/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
@@ -1,6 +1,8 @@
 import Box from "@mui/material/Box";
 import { styled } from "@mui/material/styles";
 import StandardButton from "../../common/standardButton/StandardButton";
+import { useAppDispatch } from "../../../app/hooks";
+import { clearSearch } from "../searchPanel/searchSlice";
 
 const StyledButtonContainer = styled(Box)(() => ({
   width: "100%",
@@ -11,6 +13,11 @@ const StyledButtonContainer = styled(Box)(() => ({
   backgroundColor: "#fff",
   boxShadow: "0 0 20px rgba(0, 0, 0, 0.16)",
   margin: 0,
+  "& div": {
+    width: "50%",
+    display: "flex",
+    justifyContent: "center",
+  },
   "@media (min-width: 897px)": {
     display: "none",
   },
@@ -22,27 +29,33 @@ interface ApplyFiltersProps {
   buttonAction: () => void;
 }
 
-const ApplyFilters = ({buttonText, buttonAction, disabled}: ApplyFiltersProps) => {
+const ApplyFilters = ({
+  buttonText,
+  buttonAction,
+  disabled,
+}: ApplyFiltersProps) => {
+  const dispatch = useAppDispatch();
+
+  const handleResetFilters = () => {
+    dispatch(clearSearch());
+  };
+
   return (
     <StyledButtonContainer>
-      {!disabled && (
+      <div>
         <StandardButton
           variant="outlined"
-          buttonAction={() => {
-            buttonAction();
-          }}
+          buttonAction={handleResetFilters}
+          disabled={disabled}
         >
-          
-        Reset Filters
+          Reset Filters
         </StandardButton>
-      )}
-     
-      <StandardButton
-        buttonAction={buttonAction}
-        disabled={disabled}
-      >
-        {buttonText}
-      </StandardButton>
+      </div>
+      <div>
+        <StandardButton buttonAction={buttonAction} disabled={disabled}>
+          {buttonText}
+        </StandardButton>
+      </div>
     </StyledButtonContainer>
   );
 };

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -65,14 +65,20 @@ const ResultsPanel = () => {
 
   const handleToggle = () => {
     dispatch(togglePanel());
+    console.log("panelOpen", panelOpen);
   };
 
   const handlePanelClose = () => {
+    if (!isMedium) dispatch(setSelectedTab(0));
+    dispatch(closePanel());
     dispatch(closeResultsPanel());
     console.log("panelOpen", panelOpen);
   };
 
   const handleClearSearch = () => {
+    console.log("Clear search");
+    if (!isMedium) dispatch(setSelectedTab(0));
+    // dispatch(closePanel());
     dispatch(closeResultsPanel());
     dispatch(clearSearch());
   };

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -65,20 +65,14 @@ const ResultsPanel = () => {
 
   const handleToggle = () => {
     dispatch(togglePanel());
-    console.log("panelOpen", panelOpen);
   };
 
   const handlePanelClose = () => {
-    if (!isMedium) dispatch(setSelectedTab(0));
-    dispatch(closePanel());
     dispatch(closeResultsPanel());
     console.log("panelOpen", panelOpen);
   };
 
   const handleClearSearch = () => {
-    console.log("Clear search");
-    if (!isMedium) dispatch(setSelectedTab(0));
-    // dispatch(closePanel());
     dispatch(closeResultsPanel());
     dispatch(clearSearch());
   };


### PR DESCRIPTION
#### What? Why?

Related to issue #115 

When using the search filters on a handheld device there is no option to reset any selected filters, therefore the user has to deselect each filter manually. 

#### Code-specific details (for Reviewer)
- [`apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx`](diffhunk://#diff-ad00004172893b2458508882fe610d048189e43ee3b41e5aae06eeb339933aa7R16-R20): Updated `StyledButtonContainer` styles to include a flexbox layout for child divs, ensuring buttons are centered and occupy 50% width.
- [`apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx`](diffhunk://#diff-ad00004172893b2458508882fe610d048189e43ee3b41e5aae06eeb339933aa7L25-R58): Modified the `ApplyFilters` component to include a `handleResetFilters` function and a related 'Reset Filters' button.

#### Checklist
- View the map on a phone (using a physical device, dev tools or browserstack)
- Select the search tab
- Ensure the 'Reset Filters' buttons appears and is disable
- Select a filter or multiple filters
- Ensure the 'Reset Filters' button is active
- Click on the 'Reset Filters' button and check all applied filters are cleared