### PR TITLE
117 cwm bug static results panel should animate openclose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ dist-ssr
 site
 
 *storybook.log
+
+
+# MS local test files
+ResultsPanel copy 2.tsx

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -48,8 +48,6 @@ const StyledResultsPanel = styled(Drawer)<{
   height: "100vh",
   position: "relative",
   overflow: "visible",
-  // transition: "transform 0.3s ease, opacity 0.3s ease",
-  // animation: "slideIn 0.3s ease forwards",
 
   "& .MuiDrawer-paper": {
     width: "100%",
@@ -95,7 +93,7 @@ const ResultsPanel = () => {
   const isMedium = useMediaQuery("(min-width: 897px)");
 
   const handleToggle = () => {
-      dispatch(togglePanel());
+    dispatch(togglePanel());
   };
 
   const handlePanelClose = () => {
@@ -114,37 +112,33 @@ const ResultsPanel = () => {
 
   return (
     <>
-      {panelOpen &&
-        resultsPanelOpen && ( // Adding this stops the drawer transition working
-          <StyledResultsPanel
-            open={panelOpen && resultsPanelOpen}
-            onClosePanel={!(panelOpen && resultsPanelOpen)}
-            variant="persistent"
-            anchor="left"
+      {panelOpen && resultsPanelOpen && (
+        <StyledResultsPanel
+          open={panelOpen && resultsPanelOpen}
+          onClosePanel={!(panelOpen && resultsPanelOpen)}
+          variant="persistent"
+          anchor="left"
+        >
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              height: "100%",
+            }}
           >
-            <Box
-              sx={{
-                display: "flex",
-                flexDirection: "column",
-                height: "100%",
-              }}
-            >
-              <StyledButtonContainer>
-                <StandardButton buttonAction={handleClearSearch}>
-                  {t("clear_search")}
-                </StandardButton>
-                {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
-              </StyledButtonContainer>
-              <Results />
-            </Box>
-            {isMedium && (
-              <PanelToggleButton
-                buttonAction={handleToggle}
-                isOpen={panelOpen}
-              />
-            )}
-          </StyledResultsPanel>
-        )}
+            <StyledButtonContainer>
+              <StandardButton buttonAction={handleClearSearch}>
+                {t("clear_search")}
+              </StandardButton>
+              {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
+            </StyledButtonContainer>
+            <Results />
+          </Box>
+          {isMedium && (
+            <PanelToggleButton buttonAction={handleToggle} isOpen={panelOpen} />
+          )}
+        </StyledResultsPanel>
+      )}
     </>
   );
 };

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import Drawer from "@mui/material/Drawer";
 import Box from "@mui/material/Box";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -44,22 +43,22 @@ const slideOut = keyframes`
 
 const StyledResultsPanel = styled(Drawer)<{
   onClosePanel?: boolean;
-  isClosing?: boolean;
-}>(({ onClosePanel, isClosing }) => ({
+}>(({ onClosePanel }) => ({
   width: "100%",
   height: "100vh",
   position: "relative",
   overflow: "visible",
-  transition: "transform 0.3s ease, opacity 0.3s ease",
+  // transition: "transform 0.3s ease, opacity 0.3s ease",
+  // animation: "slideIn 0.3s ease forwards",
 
   "& .MuiDrawer-paper": {
     width: "100%",
     boxSizing: "border-box",
     backgroundColor: "var(--color-secondary)",
+    visibility: "visible !important",
     overflow: "visible",
     boxShadow: "0 0 20px rgba(0, 0, 0, 0.16)",
     animation: `${onClosePanel ? slideOut : slideIn} 0.3s ease forwards`,
-    visibility: isClosing ? "hidden" : "visible",
   },
 
   "@media (min-width: 897px)": {
@@ -91,22 +90,12 @@ const ResultsPanel = () => {
   const panelOpen = useAppSelector(selectPanelOpen);
   const resultsPanelOpen = useAppSelector(selectResultsPanelOpen);
 
-  const [isVisible, setIsVisible] = useState(false);
-  const [isClosing, setIsClosing] = useState(false);
-
-  const animationDuration = 300;
+  console.log("resultsPanelOpen", resultsPanelOpen);
 
   const isMedium = useMediaQuery("(min-width: 897px)");
 
   const handleToggle = () => {
-    if (isMedium && panelOpen && resultsPanelOpen) {
-      dispatch(closeResultsPanel());
-      setTimeout(() => {
-        dispatch(togglePanel());
-      }, animationDuration);
-    } else {
       dispatch(togglePanel());
-    }
   };
 
   const handlePanelClose = () => {
@@ -119,53 +108,43 @@ const ResultsPanel = () => {
   const handleClearSearch = () => {
     console.log("Clear search");
     if (!isMedium) dispatch(setSelectedTab(0));
-    // dispatch(closePanel());
     dispatch(closeResultsPanel());
     dispatch(clearSearch());
   };
 
-  useEffect(() => {
-    if (panelOpen && resultsPanelOpen) {
-      setIsVisible(true);
-    } else {
-      const timeout = setTimeout(() => {
-        setIsVisible(false);
-        setIsClosing(false);
-      }, animationDuration);
-      return () => clearTimeout(timeout);
-    }
-  }, [panelOpen, resultsPanelOpen]);
-
   return (
     <>
-      {isVisible && (
-        <StyledResultsPanel
-          open={panelOpen && resultsPanelOpen}
-          onClosePanel={!(panelOpen && resultsPanelOpen)}
-          isClosing={isClosing}
-          variant="persistent"
-          anchor="left"
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              height: "100%",
-            }}
+      {panelOpen &&
+        resultsPanelOpen && ( // Adding this stops the drawer transition working
+          <StyledResultsPanel
+            open={panelOpen && resultsPanelOpen}
+            onClosePanel={!(panelOpen && resultsPanelOpen)}
+            variant="persistent"
+            anchor="left"
           >
-            <StyledButtonContainer>
-              <StandardButton buttonAction={handleClearSearch}>
-                {t("clear_search")}
-              </StandardButton>
-              {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
-            </StyledButtonContainer>
-            <Results />
-          </Box>
-          {isMedium && resultsPanelOpen && (
-            <PanelToggleButton buttonAction={handleToggle} isOpen={panelOpen} />
-          )}
-        </StyledResultsPanel>
-      )}
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                height: "100%",
+              }}
+            >
+              <StyledButtonContainer>
+                <StandardButton buttonAction={handleClearSearch}>
+                  {t("clear_search")}
+                </StandardButton>
+                {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
+              </StyledButtonContainer>
+              <Results />
+            </Box>
+            {isMedium && (
+              <PanelToggleButton
+                buttonAction={handleToggle}
+                isOpen={panelOpen}
+              />
+            )}
+          </StyledResultsPanel>
+        )}
     </>
   );
 };

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -22,22 +22,18 @@ import { keyframes } from "@emotion/react";
 const slideIn = keyframes`
   from {
     transform: translateX(-100%);
-    // opacity: 0;
   }
   to {
     transform: translateX(0);
-    // opacity: 1;
   }
 `;
 
 const slideOut = keyframes`
   from {
     transform: translateX(0);
-    // opacity: 1;
   }
   to {
     transform: translateX(-100%);
-    // opacity: 0;
   }
 `;
 

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -17,12 +17,37 @@ import {
 } from "../panelSlice";
 import { clearSearch } from "../searchPanel/searchSlice";
 import { useTranslation } from "react-i18next";
+import { keyframes } from "@emotion/react";
 
-const StyledResultsPanel = styled(Drawer)(() => ({
+const slideIn = keyframes`
+  from {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+`;
+
+const slideOut = keyframes`
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+`;
+
+const StyledResultsPanel = styled(Drawer)(({ theme }) => ({
   width: "100%",
   height: "100vh",
   position: "relative",
   overflow: "visible",
+  transition: "transform 0.3s ease, opacity 0.3s ease",
+
   "& .MuiDrawer-paper": {
     width: "100%",
     boxSizing: "border-box",
@@ -30,10 +55,13 @@ const StyledResultsPanel = styled(Drawer)(() => ({
     visibility: "visible !important",
     overflow: "visible",
     boxShadow: "0 0 20px rgba(0, 0, 0, 0.16)",
+    animation: `${slideIn} 0.3s ease forwards`, // 👈 Animate on entry
   },
+
   "@media (min-width: 897px)": {
     width: "calc(var(--panel-width-desktop) + 30px)",
     transform: "translateX(var(--panel-width-desktop))",
+
     "& .MuiDrawer-paper": {
       width: "var(--panel-width-desktop)",
     },

--- a/apps/front-end/src/theme/GlobalCSSVariables.tsx
+++ b/apps/front-end/src/theme/GlobalCSSVariables.tsx
@@ -20,7 +20,6 @@ const rootVariables = {
   "--spacing-xxlarge": "40px",
   "--spacing-xxxlarge": "48px",
   "--panel-width-desktop": "375px",
-  "--minus-panel-width-desktop": "-375px",
   "--font-size-xsmall": "12px",
   "--font-size-small": "14px",
   "--font-size-medium": "16px",

--- a/apps/front-end/src/theme/GlobalCSSVariables.tsx
+++ b/apps/front-end/src/theme/GlobalCSSVariables.tsx
@@ -20,6 +20,7 @@ const rootVariables = {
   "--spacing-xxlarge": "40px",
   "--spacing-xxxlarge": "48px",
   "--panel-width-desktop": "375px",
+  "--minus-panel-width-desktop": "-375px",
   "--font-size-xsmall": "12px",
   "--font-size-small": "14px",
   "--font-size-medium": "16px",


### PR DESCRIPTION
#### What? Why?

Related to issue #117 

When the results panel is closed and then reopened, the directory/search panel slides out as expected, but the results panel appears on screen without any animation. This is due to the `ResultsPanel` being unmounted on closure and unavailable in the DOM, meaning that the MUI `Drawer` component's animations do not fire.

#### Code-specific details (for Reviewer)

Updates to the `ResultsPanel` component in the `apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx` file to add animation effects. 

* Added `keyframes` import from `@emotion/react` and defined `slideIn` and `slideOut` keyframes for animation effects.
* Updated `StyledResultsPanel` to use the `slideIn` and `slideOut` animations based on the `onClosePanel` prop.


<!-- Any details to help the Reviewer to understand your code changes
     e.g. files to pay special attention to, the structure of the commits  -->

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

  - Load map
  - Open the Directory tab
  - Click on Argentina
  - Close the results panel via the green tab
  - Open via the green tab
  - The results panel should animate open, along with the directory panel

The above process can also be repeated via the Search tab

