### PR TITLE
change zoom to be initialised from maxZoom

### DIFF
--- a/apps/front-end/src/components/map/mapLibre.ts
+++ b/apps/front-end/src/components/map/mapLibre.ts
@@ -344,9 +344,9 @@ export const createMap = (
         ) as GeoJSON.Feature<GeoJSON.Point>;
       };
 
-      let zoom = 10; // start with this zoom, then hone in
       let spiderfied = false; // spiderfy when we get into the condition
       const maxZoom = 18; // once we get to this zoom, stop
+      let zoom = maxZoom;
 
       const flyToThenOpenPopupRecursive = () => {
         const feature = getFeatureIfVisible(itemIx);
@@ -357,15 +357,11 @@ export const createMap = (
             .flyTo({
               center: [
                 location[0],
-                getMapCentreLatOffsetted(location[1], zoom),
+                getMapCentreLatOffsetted(location[1], maxZoom),
               ],
-              zoom,
+              zoom
             })
-            .once("moveend", async () => {
-              if (zoom < maxZoom) {
-                zoom += 2;
-                flyToThenOpenPopupRecursive();
-              } else {
+            .once("moveend", async () => {             
                 console.error(
                   "Maybe the feature is in a cluster and needs to be spiderfied.",
                 );
@@ -381,7 +377,6 @@ export const createMap = (
                   });
                   spiderfied = true;
                 }
-              }
             });
         } else {
           // Do a final fly to position the marker nicely without zooming,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "mykomap-monolith",
       "workspaces": [
         "apps/*",
         "libs/*"


### PR DESCRIPTION
#### What? Why?

Related to issue #103

We decided to try out having the zoom level set to max each time, to avoid the recursive zooming

#### Code-specific details (for Reviewer)

Haven't dug deep into the flyTo method, but it requires an editable variable for `zoom` for some reason

#### Checklist

- [X] Updated or added any necessary docs in `docs/`
- [X] Added UTs
- [X] Checked that all automated tests pass

#### What should we test? (for QA)

- open directory on side
- select any country
- select an item
- watch as it zooms to max to the item

#### Deployment notes

none
