### PR TITLE
150 powys disable auto alphabetise categories

### DIFF
--- a/apps/front-end/src/components/panel/searchPanel/searchSlice.test.ts
+++ b/apps/front-end/src/components/panel/searchPanel/searchSlice.test.ts
@@ -286,3 +286,226 @@ describe("setFilterValue", () => {
     });
   });
 });
+
+// Test sorting of filter options
+describe("sort filter options", () => {
+  // Mock configuration for testing - non alphabetical order
+  const baseConfig = {
+    currentLanguage: "en",
+    vocabs: {
+      aci: {
+        en: {
+          title: "Economic Activity",
+          terms: {
+            ICA220: "Transport",
+            ICA210: "Housing",
+            ICA230: "Utilities",
+          },
+        },
+      },
+      coun: {
+        en: {
+          title: "Country",
+          terms: {
+            GB: "United Kingdom",
+            FR: "France",
+          },
+        },
+      },
+      ui: {
+        en: {
+          title: "Translations",
+          terms: {
+            primary_activity: "Primary Activity",
+            typology: "Typology",
+            country_id: "Country",
+          },
+        },
+      },
+    },
+  };
+
+  const getBaseState = (filterableVocabProps: any[]) => ({
+    search: {
+      text: "",
+      visibleIndexes: [],
+      searchingStatus: "idle",
+      filterableVocabProps,
+    },
+    config: structuredClone(baseConfig),
+  });
+
+  // Test default sorting (no sort specified)
+  test("sort options ascending order by default", () => {
+    const state = getBaseState([
+      {
+        id: "primary_activity",
+        titleUri: "ui:primary_activity",
+        value: "any",
+        vocabUri: "aci",
+      },
+      {
+        id: "country_id",
+        titleUri: "ui:country_id",
+        value: "any",
+        vocabUri: "coun",
+      },
+    ]);
+
+    expect(selectFilterOptions(state)).toEqual([
+      {
+        id: "primary_activity",
+        title: "Primary Activity",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "ICA210", label: "Housing" },
+          { value: "ICA220", label: "Transport" },
+          { value: "ICA230", label: "Utilities" },
+        ],
+        value: "any",
+      },
+      {
+        id: "country_id",
+        title: "Country",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "FR", label: "France" },
+          { value: "GB", label: "United Kingdom" },
+        ],
+        value: "any",
+      },
+    ]);
+  });
+
+  // Test ascending sort
+  test("sort options ascending order", () => {
+    const state = getBaseState([
+      {
+        id: "primary_activity",
+        titleUri: "ui:primary_activity",
+        value: "any",
+        vocabUri: "aci",
+        sorted: "asc",
+      },
+      {
+        id: "country_id",
+        titleUri: "ui:country_id",
+        value: "any",
+        vocabUri: "coun",
+        sorted: "asc",
+      },
+    ]);
+
+    expect(selectFilterOptions(state)).toEqual([
+      {
+        id: "primary_activity",
+        title: "Primary Activity",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "ICA210", label: "Housing" },
+          { value: "ICA220", label: "Transport" },
+          { value: "ICA230", label: "Utilities" },
+        ],
+        value: "any",
+      },
+      {
+        id: "country_id",
+        title: "Country",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "FR", label: "France" },
+          { value: "GB", label: "United Kingdom" },
+        ],
+        value: "any",
+      },
+    ]);
+  });
+
+  // Test descending sort
+  test("sort options descending order", () => {
+    const state = getBaseState([
+      {
+        id: "primary_activity",
+        titleUri: "ui:primary_activity",
+        value: "any",
+        vocabUri: "aci",
+        sorted: "desc",
+      },
+      {
+        id: "country_id",
+        titleUri: "ui:country_id",
+        value: "any",
+        vocabUri: "coun",
+        sorted: "desc",
+      },
+    ]);
+
+    expect(selectFilterOptions(state)).toEqual([
+      {
+        id: "primary_activity",
+        title: "Primary Activity",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "ICA230", label: "Utilities" },
+          { value: "ICA220", label: "Transport" },
+          { value: "ICA210", label: "Housing" },
+        ],
+        value: "any",
+      },
+      {
+        id: "country_id",
+        title: "Country",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "GB", label: "United Kingdom" },
+          { value: "FR", label: "France" },
+        ],
+        value: "any",
+      },
+    ]);
+  });
+
+  // Test sort options set to false
+  test("sort options set to false", () => {
+    const state = getBaseState([
+      {
+        id: "primary_activity",
+        titleUri: "ui:primary_activity",
+        value: "any",
+        vocabUri: "aci",
+        sorted: false,
+      },
+      {
+        id: "country_id",
+        titleUri: "ui:country_id",
+        value: "any",
+        vocabUri: "coun",
+        sorted: false,
+      },
+    ]);
+
+    expect(selectFilterOptions(state)).toEqual([
+      {
+        id: "primary_activity",
+        title: "Primary Activity",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "ICA220", label: "Transport" },
+          { value: "ICA210", label: "Housing" },
+          { value: "ICA230", label: "Utilities" },
+        ],
+        value: "any",
+      },
+      {
+        id: "country_id",
+        title: "Country",
+        options: [
+          { value: "any", label: "- any -" },
+          { value: "GB", label: "United Kingdom" },
+          { value: "FR", label: "France" },
+        ],
+        value: "any",
+      },
+    ]);
+  });
+});

--- a/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
+++ b/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
@@ -8,7 +8,6 @@ import { populateSearchResults } from "../panelSlice";
 import { AppThunk } from "../../../app/store";
 import i18n from "../../../i18n";
 import { VocabDef } from "@mykomap/common";
-import { a } from "vitest/dist/suite-IbNSsUWN.js";
 
 type FilterableVocabProp = {
   id: string;

--- a/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
+++ b/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
@@ -137,7 +137,7 @@ export const {
 export const { selectText, selectVisibleIndexes, selectIsFilterActive } =
   searchSlice.selectors;
 
-// add sort function asc / desc / no sort
+// Add sort function asc / desc / no sort
 type Term = VocabDef["terms"];
 type TermSorter = (a: Term, b: Term) => number;
 const acendingSort: TermSorter = (a, b) => a.label.localeCompare(b.label);
@@ -185,11 +185,6 @@ export const selectFilterOptions = createSelector(
             sorter = acendingSort;
             break;
         }
-
-        // *FIXME -  Remove after testing
-        console.log(
-          `selectFilterOptions: prop.id=${prop.id}, title=${title}, sorted=${prop.sorted}`,
-        );
 
         return {
           id: prop.id,

--- a/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
+++ b/apps/front-end/src/components/panel/searchPanel/searchSlice.ts
@@ -8,6 +8,7 @@ import { populateSearchResults } from "../panelSlice";
 import { AppThunk } from "../../../app/store";
 import i18n from "../../../i18n";
 import { VocabDef } from "@mykomap/common";
+import { a } from "vitest/dist/suite-IbNSsUWN.js";
 
 type FilterableVocabProp = {
   id: string;
@@ -137,12 +138,7 @@ export const {
 export const { selectText, selectVisibleIndexes, selectIsFilterActive } =
   searchSlice.selectors;
 
-// Add sort function asc / desc / no sort
 type Term = VocabDef["terms"];
-type TermSorter = (a: Term, b: Term) => number;
-const acendingSort: TermSorter = (a, b) => a.label.localeCompare(b.label);
-const descendingSort: TermSorter = (a, b) => b.label.localeCompare(a.label);
-const noSort: TermSorter = (a, b) => 0;
 
 export const selectFilterOptions = createSelector(
   [
@@ -169,22 +165,18 @@ export const selectFilterOptions = createSelector(
             ]
           : vocabs[prop.vocabUri][language].title;
 
-        // Check you sort via a switch function // boolean / asc / desc /undenfined
-        let sorter = acendingSort;
-        switch (prop.sorted) {
-          case "asc":
-            sorter = acendingSort;
-            break;
-          case "desc":
-            sorter = descendingSort;
-            break;
-          case false:
-            sorter = noSort;
-            break;
-          default:
-            sorter = acendingSort;
-            break;
-        }
+        // Define sorters for ascending, descending, and no sort
+        const sorters = {
+          asc: (a: Term, b: Term) => a.label.localeCompare(b.label),
+          desc: (a: Term, b: Term) => b.label.localeCompare(a.label),
+          noSort: (a: Term, b: Term) => 0,
+        };
+
+        const sorter =
+          prop.sorted === false
+            ? sorters.noSort
+            : (prop.sorted && sorters[prop.sorted as keyof typeof sorters]) ||
+              sorters.asc;
 
         return {
           id: prop.id,

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -79,6 +79,9 @@ const InnerValuePropSpec = z.object({
 const InnerVocabPropSpec = z.object({
   type: z.literal("vocab"),
   uri: AbbrevUri,
+  sorted: z
+    .union([z.boolean(), z.literal("asc"), z.literal("desc")])
+    .optional(),
 });
 const InnerPropSpec = z.union([InnerValuePropSpec, InnerVocabPropSpec]);
 const OuterMultiPropSpec = z.object({

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -79,6 +79,12 @@ const InnerValuePropSpec = z.object({
 const InnerVocabPropSpec = z.object({
   type: z.literal("vocab"),
   uri: AbbrevUri,
+  /**
+   * Indicates whether the options should be sorted in filter dropdowns.
+   * If set to false, no sorting will occur.
+   * sorting is set to 'asc' by default
+   * If set to 'asc' or 'desc', the options will be sorted accordingly.
+   */
   sorted: z
     .union([z.boolean(), z.literal("asc"), z.literal("desc")])
     .optional(),

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -82,7 +82,7 @@ const InnerVocabPropSpec = z.object({
   /**
    * Indicates whether the options should be sorted in filter dropdowns.
    * If set to false, no sorting will occur.
-   * sorting is set to 'asc' by default
+   * Sorting is set to 'asc' by default
    * If set to 'asc' or 'desc', the options will be sorted accordingly.
    */
   sorted: z

--- a/libs/common/src/api/mykomap-openapi.json
+++ b/libs/common/src/api/mykomap-openapi.json
@@ -563,6 +563,25 @@
                               },
                               "uri": {
                                 "type": "string"
+                              },
+                              "sorted": {
+                                "oneOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "asc"
+                                    ]
+                                  },
+                                  {
+                                    "type": "string",
+                                    "enum": [
+                                      "desc"
+                                    ]
+                                  }
+                                ]
                               }
                             },
                             "required": [
@@ -653,6 +672,25 @@
                                       },
                                       "uri": {
                                         "type": "string"
+                                      },
+                                      "sorted": {
+                                        "oneOf": [
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "enum": [
+                                              "asc"
+                                            ]
+                                          },
+                                          {
+                                            "type": "string",
+                                            "enum": [
+                                              "desc"
+                                            ]
+                                          }
+                                        ]
                                       }
                                     },
                                     "required": [


### PR DESCRIPTION
### What? Why?
Auto-alphabetisation was removed from [front-end] `searchSlice.ts` in provision for nested categories within the Powys map.

Filter options can now be sorted in ascending or descending order, and sorting can also be set to false. A `sorted` property was added to filterable vocabularies, the API contract updated to accommodate the new property and sorting logic added to the front-end. Tests were also added to `searchSlice.test.ts`

**Related to issue #150**

### Front-end updates:
* [`apps/front-end/src/components/panel/searchPanel/searchSlice.ts`](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR10-R17): Added a `sorted` property to `FilterableVocabProp` and implemented sorting logic using a switch statement to handle ascending, descending, or no sorting for filter options. Updated the `selectFilterOptions` selector to use the specified sorting method. [[1]](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR10-R17) [[2]](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR95) [[3]](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR106) [[4]](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR140-R146) [[5]](diffhunk://#diff-6ad97ba584ed905c60cda3671470df7ca8284375e65f3c8ade2803885db4aa4eR172-R196)

* [`apps/front-end/src/components/panel/searchPanel/searchSlice.test.ts`](diffhunk://#diff-0421f6f0bb8017d7649d7630037931a2707ed3ae1ef525fe9057dc11333a2e6bR289-R511): Added tests to verify sorting functionality for filter options, including ascending order, descending order, and no sorting.

### API updates:

* [`libs/common/src/api/contract.ts`](diffhunk://#diff-f69791e89fee29a96dea44bb4471ec497b38bc8c316f2653a0ed41167c8cd147R82-R90): Added an optional `sorted` property to the `InnerVocabPropSpec` object to indicate sorting preferences for filter dropdowns.

* [TSDoc](https://tsdoc.org/) commenting was added to the above for future extraction into documentation.

* [`libs/common/src/api/mykomap-openapi.json`](diffhunk://#diff-703e175e40071d2e1158ac95b7a52fe4f946d6393d667fbeeede71183edda0b5R566-R584): Updated the OpenAPI specification to include the `sorted` property, supporting boolean values and strings (`asc` or `desc`) for sorting options. [[1]](diffhunk://#diff-703e175e40071d2e1158ac95b7a52fe4f946d6393d667fbeeede71183edda0b5R566-R584) [[2]](diffhunk://#diff-703e175e40071d2e1158ac95b7a52fe4f946d6393d667fbeeede71183edda0b5R675-R693)

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass






