### PR TITLE
update config and docs for relative links

### DIFF
--- a/apps/back-end/test/data/datasets/dataset-A/config.json
+++ b/apps/back-end/test/data/datasets/dataset-A/config.json
@@ -20,8 +20,8 @@
       ]
     },
     "logo": {
-      "largeLogo": "/assets/logos/cwm-logo.png",
-      "smallLogo": "/assets/logos/cwm-logo-small.png",
+      "largeLogo": "./assets/logos/cwm-logo.png",
+      "smallLogo": "./assets/logos/cwm-logo-small.png",
       "altText": "Cooperative World Map",
       "smallScreenPosition": {
         "top": "0",

--- a/docs/config.md
+++ b/docs/config.md
@@ -65,8 +65,8 @@ The `logo` field has 6 subfields
 ```
 "ui": {
   "logo": {
-    "largeLogo": "/assets/logos/cwm-logo.png",
-    "smallLogo": "/assets/logos/cwm-logo-small.png",
+    "largeLogo": "./assets/logos/cwm-logo.png",
+    "smallLogo": "./assets/logos/cwm-logo-small.png",
     "altText": "Cooperative World Map",
     "smallScreenPosition": {
       "top": "0",


### PR DESCRIPTION
#### What? Why?

Config images need relative links because we host mykomap in a subdirectory  i.e. maps.coop/cwm

When you host it's own domain, the previous links were fine but the subdirectory requires a dot in front

#### Code-specific details (for Reviewer)

<!-- Any details to help the Reviewer to understand your code changes
     e.g. files to pay special attention to, the structure of the commits  -->

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass

#### What should we test? (for QA)

<!-- List which features should be tested and how.
     Also think of other parts of the app which could be affected
     by your change. -->

- Click '...'

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
