### PR TITLE
make the width configurable

### DIFF
--- a/apps/front-end/src/app/configSlice.ts
+++ b/apps/front-end/src/app/configSlice.ts
@@ -35,6 +35,7 @@ export type PopupItemConfigNoMultiple = {
 
 export type ConfigPopupNoMultiple = {
   titleProp: string;
+  leftPaneWidth: string;
   leftPane: PopupItemConfigNoMultiple[];
   topRightPane: PopupItemConfigNoMultiple[];
   bottomRightPane: PopupItemConfigNoMultiple[];
@@ -46,6 +47,7 @@ export type PopupItemConfig = PopupItemConfigNoMultiple & {
 
 export type ConfigPopup = {
   titleProp: string;
+  leftPaneWidth: string;
   leftPane: PopupItemConfig[];
   topRightPane: PopupItemConfig[];
   bottomRightPane: PopupItemConfig[];
@@ -79,6 +81,7 @@ const initialState: ConfigSliceState = {
   status: "idle",
   popup: {
     titleProp: "name",
+    leftPaneWidth: "70%",
     leftPane: [],
     topRightPane: [],
     bottomRightPane: [],
@@ -89,6 +92,7 @@ function deriveMultiples(popupConfigRaw: ConfigPopupNoMultiple, itemProps: any) 
   const { leftPane, topRightPane, bottomRightPane } = popupConfigRaw;
   const popupConfig: ConfigPopup = {
     titleProp: popupConfigRaw.titleProp,
+    leftPaneWidth: popupConfigRaw.leftPaneWidth,
     leftPane: leftPane.map(itemConfig => ({ ...itemConfig, multiple: itemProps[itemConfig.itemProp].type === "multi" })),
     topRightPane: topRightPane.map(itemConfig => ({ ...itemConfig, multiple: itemProps[itemConfig.itemProp].type === "multi" })),
     bottomRightPane: bottomRightPane.map(itemConfig => ({ ...itemConfig, multiple: itemProps[itemConfig.itemProp].type === "multi" })),

--- a/apps/front-end/src/components/popup/Popup.tsx
+++ b/apps/front-end/src/components/popup/Popup.tsx
@@ -70,22 +70,18 @@ const Popup = () => {
   const popupIndex = useAppSelector(selectPopupIndex);
   const hasLocation = !!useAppSelector(selectLocation(popupIndex));
   const data = useAppSelector(selectPopupData);
-  const popupConfig = useAppSelector(selectPopupConfig) || {
-    titleProp: "name",
-    leftPane: [],
-    topRightPane: [],
-    bottomRightPane: [],
-  };
+  const popupConfig = useAppSelector(selectPopupConfig);
 
   if (open) console.log("Popup data", data);
 
-  const popupComponent = data ? (
+  const popupComponent = data && popupConfig ? (
     <StyledPopup>
       <StylePopupInner>
         <LeftPane
           data={data}
           hasLocation={hasLocation}
           config={popupConfig.leftPane}
+          width={popupConfig.leftPaneWidth}
           titleProp={popupConfig.titleProp}
         />
         <RightPane

--- a/apps/front-end/src/components/popup/leftPane/LeftPane.tsx
+++ b/apps/front-end/src/components/popup/leftPane/LeftPane.tsx
@@ -9,15 +9,16 @@ interface LeftPaneProps {
   data: { [key: string]: any };
   hasLocation: boolean;
   config: PopupItemConfig[];
+  width: string;
   titleProp: string;
 }
 
-const StyledLeftPane = styled(Box)(() => ({
+const StyledLeftPane = styled(Box)(({ width }) => ({
   display: "flex",
   flexDirection: "column",
   margin: "var(--spacing-large)",
   "@media (min-width: 768px)": {
-    width: "70%",
+    width: width,
     flexDirection: "column",
     margin:
       "var(--spacing-large) 0 var(--spacing-xlarge) var(--spacing-xlarge)",
@@ -82,11 +83,11 @@ const StyledContentContainer = styled(Box)(() => ({
   },
 }));
 
-const LeftPane = ({ data, hasLocation, config, titleProp }: LeftPaneProps) => {
+const LeftPane = ({ data, hasLocation, config, width, titleProp }: LeftPaneProps) => {
   const { t } = useTranslation();
 
   return (
-    <StyledLeftPane>
+    <StyledLeftPane width={width}>
       <StyledHeaderContainer>
         <Typography variant="h1" sx={{ overflowWrap: "break-word" }}>
           {data[titleProp]}

--- a/libs/common/src/api/contract.ts
+++ b/libs/common/src/api/contract.ts
@@ -155,6 +155,7 @@ const ConfigData = z.object({
   }),
   popup: z.object({
     titleProp: z.string(),
+    leftPaneWidth: z.string().default("70%"),
     leftPane: z.array(PopupItem),
     topRightPane: z.array(PopupItem),
     bottomRightPane: z.array(PopupItem)

--- a/libs/common/src/api/mykomap-openapi.json
+++ b/libs/common/src/api/mykomap-openapi.json
@@ -973,6 +973,10 @@
                         "titleProp": {
                           "type": "string"
                         },
+                        "leftPaneWidth": {
+                          "default": "70%",
+                          "type": "string"
+                        },
                         "leftPane": {
                           "type": "array",
                           "items": {


### PR DESCRIPTION
#### What? Why?

Related to issue #204

Add config value `leftPaneWidth` to popup config, with a default value of 70%

#### Code-specific details (for Reviewer)

<!-- Any details to help the Reviewer to understand your code changes
     e.g. files to pay special attention to, the structure of the commits  -->

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass

#### What should we test? (for QA)

- Open powys-eng and notice the luxurious extra space for email address
- Open cwm-latest and notice that the popups look the same as they ever did

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
