### PR TITLE
[front-end] open results panel on mobile if results exist

### DIFF
--- a/apps/front-end/src/components/panel/Panel.tsx
+++ b/apps/front-end/src/components/panel/Panel.tsx
@@ -24,6 +24,7 @@ import {
 import {
   performSearch,
   selectIsFilterActive,
+  selectVisibleIndexes,
 } from "../panel/searchPanel/searchSlice";
 import { useTranslation } from "react-i18next";
 
@@ -61,9 +62,11 @@ const Panel = () => {
   const selectedTab = useAppSelector(selectSelectedTab);
   const resultsOpen = useAppSelector(selectResultsPanelOpen);
   const isFilterActive = useAppSelector(selectIsFilterActive);
+  const visibleIndexes = useAppSelector(selectVisibleIndexes);
   const { t } = useTranslation();
 
   const isMedium = useMediaQuery("(min-width: 897px)");
+
 
   const handleToggle = () => {
     dispatch(togglePanel());
@@ -76,6 +79,11 @@ const Panel = () => {
     } else {
       dispatch(openPanel()); // Show the panel if any other tab is selected
     }
+
+    if (!isMedium && tab === 2 && isFilterActive && visibleIndexes.length > 0) {
+      dispatch(openResultsPanel()); // Open results panel on mobile if there are results
+    }
+
     dispatch(setSelectedTab(tab));
     console.log("tab", tab);
   };


### PR DESCRIPTION
#### What? Why?

Fixes #185 

After performing a search and selecting a result on mobile, you cannot return to the search results without reproducing the search. I have updated the logic in `Panel.tsx`, so that if a search has been performed, tapping the search tab will return you to the results panel.

#### Code-specific details (for Reviewer)
* Added a check in the tab selection handler to automatically open the results panel on mobile (`!isMedium`) when the user selects tab 2, a filter is active, and there are visible search results.
* Integrated the `selectVisibleIndexes` selector into the component to determine if there are visible results after filtering. [[1]](diffhunk://#diff-375ae61a737aaef08b2827fdcb7afad7692cdc743a072dde77347cf8ac2856c0R27) [[2]](diffhunk://#diff-375ae61a737aaef08b2827fdcb7afad7692cdc743a072dde77347cf8ac2856c0R65-R70)

#### What should we test? (for QA)

- Perform a search on mobile
- Tap on a result
- Tap on the search tab
- Search results pane should be visible
- Clear the search results
- Tap on a tab other than the search tab
- Return to the search page
- The filters page should be visible
- Perform a search that returns 0 matches
- Tap on a tab other than the search tab
- Return to the search pane
- The filters page rather than the results should be displayed



