### PR TITLE
228 Hide the results panel instead of destroying it so scroll state remains

### DIFF
--- a/apps/front-end/src/components/panel/Panel.tsx
+++ b/apps/front-end/src/components/panel/Panel.tsx
@@ -67,10 +67,8 @@ const Panel = () => {
 
   const isMedium = useMediaQuery("(min-width: 897px)");
 
-
   const handleToggle = () => {
     dispatch(togglePanel());
-    console.log("isOpen", isOpen);
   };
 
   const handleTabChange = (tab: number) => {
@@ -91,7 +89,6 @@ const Panel = () => {
   const handlePanelClose = () => {
     dispatch(closePanel());
     if (!isMedium) dispatch(setSelectedTab(0));
-    console.log("isOpen", isOpen);
   };
 
   const handleMapTapClick = () => {

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -36,8 +36,10 @@ const slideOut = keyframes`
 `;
 
 const StyledResultsPanel = styled(Drawer)<{
+  open: boolean;
   onClosePanel?: boolean;
-}>(({ onClosePanel }) => ({
+}>(({ open, onClosePanel }) => ({
+  display: `${open ? "block" : "none"}`,
   width: "100%",
   height: "100vh",
   position: "relative",
@@ -101,35 +103,31 @@ const ResultsPanel = () => {
   };
 
   return (
-    <>
-      {panelOpen && resultsPanelOpen && (
-        <StyledResultsPanel
-          open={panelOpen && resultsPanelOpen}
-          onClosePanel={!(panelOpen && resultsPanelOpen)}
-          variant="persistent"
-          anchor="left"
-        >
-          <Box
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              height: "100%",
-            }}
-          >
-            <StyledButtonContainer>
-              <StandardButton buttonAction={handleClearSearch}>
-                {t("clear_search")}
-              </StandardButton>
-              {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
-            </StyledButtonContainer>
-            <Results />
-          </Box>
-          {isMedium && (
-            <PanelToggleButton buttonAction={handleToggle} isOpen={panelOpen} />
-          )}
-        </StyledResultsPanel>
+    <StyledResultsPanel
+      open={panelOpen && resultsPanelOpen}
+      onClosePanel={!(panelOpen && resultsPanelOpen)}
+      variant="persistent"
+      anchor="left"
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+        }}
+      >
+        <StyledButtonContainer>
+          <StandardButton buttonAction={handleClearSearch}>
+            {t("clear_search")}
+          </StandardButton>
+          {!isMedium && <CloseButton buttonAction={handlePanelClose} />}
+        </StyledButtonContainer>
+        <Results />
+      </Box>
+      {isMedium && (
+        <PanelToggleButton buttonAction={handleToggle} isOpen={panelOpen} />
       )}
-    </>
+    </StyledResultsPanel>
   );
 };
 


### PR DESCRIPTION
#### What? Why?

Fixes #228 

Not much more detail is needed, it's a small fix

<!-- Explain why this change is needed and the solution you propose.
     Provide context for others to understand it. -->

#### Code-specific details (for Reviewer)

<!-- Any details to help the Reviewer to understand your code changes
     e.g. files to pay special attention to, the structure of the commits  -->
I initially used Claude code to tackle this and it tried to use a fairly obscure external library 'use-scroll-restoration' hook to try to track and restore scroll position. But then it tried to add more complicated layers of useEffect logic to get it to work whilst also being able to reset the scroll position when the results page changed. It might have reached an extremely complicated workaround eventually, but I eventually had to manually intervene and revert its edits and do this fix myself.

#### Checklist

- No docs needed
- No UTs needed
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

<!-- List which features should be tested and how.
     Also think of other parts of the app which could be affected
     by your change. -->

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
