### PR TITLE
202 /  201 CWM introduce badge for co-located clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,6 @@ site
 
 # MS local test files
 ResultsPanel copy 2.tsx
+apps/back-end/test/data/datasets/
 
 bin/do-release.mjs

--- a/apps/front-end/src/components/map/mapLibre.ts
+++ b/apps/front-end/src/components/map/mapLibre.ts
@@ -21,10 +21,11 @@ export const POPUP_CONTAINER_ID = "popup-container";
 /** The level to which we zoom when jumping to a popup, on clicking a search result */
 const POPUP_INITIAL_ZOOM = 15;
 
-/** Note: We ONLY USE INDEXES in this file. MapLibre doesn't know about IDs. Read architecture.md */
-let popupIx: number | undefined;
 let popup: Popup | undefined;
+let popupIx: number | undefined;
 let tooltip: Popup | undefined;
+let colocatedClusterIds = new Set<number>();
+let currentSpiderfiedClusterId: number | null = null;
 
 /**
  * We need to offset latitude of the map centre slightly above a marker's location when opening a
@@ -68,6 +69,21 @@ const disableRotation = (map: Map) => {
   map.touchZoomRotate.disableRotation();
 };
 
+/**
+ * Update badge visibility to hide badges on spiderfied clusters
+ */
+const updateBadgeVisibility = (map: Map) => {
+  const colocatedBadgeFilter = [
+    "all",
+    ["has", "point_count"],
+    ["in", ["get", "cluster_id"], ["literal", Array.from(colocatedClusterIds)]],
+    // Hide badge if this cluster is currently spiderfied
+    ["!=", ["get", "cluster_id"], currentSpiderfiedClusterId ?? -1],
+  ];
+  map.setFilter("colocated-badge-circle", colocatedBadgeFilter as any);
+  map.setFilter("colocated-badge-icon", colocatedBadgeFilter as any);
+};
+
 const openPopup = async (
   map: Map,
   itemIx: number,
@@ -77,20 +93,18 @@ const openPopup = async (
   offset?: [number, number],
 ) => {
   if (popup?.isOpen() && popupIx === itemIx) {
-    console.log(`Popup for item ${itemIx} already open`);
+    console.log(`Popup for item @${itemIx} already open`);
     return;
   }
 
-  console.log(`Create marker popup for item @${itemIx}`);
+  console.log(`Open popup for item @${itemIx} ${coordinates}`);
 
   // Shift the popup up a bit so it doesn't cover the marker
   const popupOffset: [number, number] = offset
     ? [offset[0], offset[1] - 20]
     : [0, -20];
 
-  popup?.off("close", popupClosedCallback);
   popup?.remove();
-
   popupIx = itemIx;
   popup = new Popup({
     closeButton: false,
@@ -136,7 +150,6 @@ const onMarkerHover = (
 export const createMap = (
   popupCreatedCallback: (itemIx: number) => void,
   popupClosedCallback: () => void,
-  mapCreated: () => void,
   mapConfig?: {
     mapBounds?: [[number, number], [number, number]];
   },
@@ -196,6 +209,58 @@ export const createMap = (
         "text-field": ["get", "point_count_abbreviated"],
         "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
         "text-size": 12,
+        "text-allow-overlap": true, // Ensure text always shows
+      },
+    });
+
+    // SVG icon for co-located badge
+    const svg = `
+      <svg viewBox="0 0 12 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path 
+          d="M6.29793.0680478c-.18751-.0907304-.40835-.0907304-.59586 0L.36845 2.64882c-.3291847.15929-.4625251.5464-.297933.86497.164592.31856.564613.4476.893798.28832L6 1.3665l5.0357 2.43561c.3292.15928.7292.03024.8938-.28832.1646-.31857.0312-.70568-.2979-.86497L6.29793.0680478ZM6 5.80624c.30944 0 .6062-.11896.825-.3307.21881-.21175.34173-.49894.34173-.79839 0-.29945-.12292-.58664-.34173-.79839-.2188-.21174-.51556-.3307-.825-.3307-.30944 0-.6062.11896-.825.3307-.21881.21175-.34173.49894-.34173.79839 0 .29945.12292.58664.34173.79839.2188.21174.51556.3307.825.3307Zm0 .96779c-1.10423 0-2.00011.86698-2.00011 1.93558v.6452c0 .35687.29794.64519.66671.64519h2.66681c.36876 0 .6667-.28832.6667-.64519v-.6452c0-1.0686-.89588-1.93558-2.00011-1.93558ZM3.33319 5.48364c0-.12709-.02587-.25294-.07612-.37035-.05026-.11742-.12392-.22411-.21679-.31398-.09286-.08987-.20311-.16115-.32444-.20979-.12133-.04863-.25137-.07367-.3827-.07367s-.26137.02504-.38271.07367c-.12133.04864-.23157.11992-.32444.20979-.09286.08987-.16652.19656-.21678.31398-.05026.11741-.07613.24326-.07613.37035 0 .1271.02587.25294.07613.37036.05026.11742.12392.22411.21678.31397.09287.08987.20311.16116.32444.2098.12134.04863.25138.07366.38271.07366s.26137-.02503.3827-.07366c.12133-.04864.23158-.11993.32444-.2098.09287-.08986.16653-.19655.21679-.31397.05025-.11742.07612-.24326.07612-.37036Zm7.33371 0c0-.25667-.1053-.50283-.2929-.68433-.1875-.18149-.44191-.28346-.70714-.28346-.26523 0-.5196.10197-.70714.28346-.18755.1815-.29291.42766-.29291.68433 0 .25668.10536.50284.29291.68433.18754.1815.44191.28346.70714.28346.26523 0 .51964-.10196.70714-.28346.1876-.18149.2929-.42765.2929-.68433ZM2.33314 7.09663c-.92088 0-1.666758.72181-1.666758 1.61298v.66737c0 .34276.287516.62302.643788.62302h1.82926c-.08959-.19759-.13959-.41534-.13959-.64519v-.96779c0-.37099.07292-.72585.20418-1.05248-.25418-.15121-.55212-.23791-.87088-.23791ZM8.86265 10h1.82925c.3542 0 .6438-.27824.6438-.62302v-.66737c0-.89117-.7459-1.61298-1.66675-1.61298-.31877 0-.6167.0867-.87088.23791.13125.32663.20417.68149.20417 1.05248v.96779c0 .22985-.05.4476-.13959.64519Z" 
+          fill="#fff"
+        />
+      </svg>
+    `;
+    const img = new Image(12, 10);
+    img.src = "data:image/svg+xml;base64," + btoa(svg);
+
+    // Wait for image to load before adding the layer
+    await new Promise<void>((resolve) => {
+      img.onload = () => {
+        map.addImage("colocated-icon", img);
+        resolve();
+      };
+    });
+
+    // Badge circle
+    map.addLayer({
+      id: "colocated-badge-circle",
+      type: "circle",
+      source: "items-geojson",
+      filter: ["==", "cluster_id", -1], // Initially hide all badges
+      paint: {
+        "circle-radius": 10,
+        "circle-color": "#535F6D",
+        "circle-translate": [15, -15], // Offset to top-right of cluster
+      },
+    });
+
+    // Badge icon
+    map.addLayer({
+      id: "colocated-badge-icon",
+      type: "symbol",
+      source: "items-geojson",
+      filter: ["==", "cluster_id", -1], // Initially hide all badges
+      layout: {
+        "icon-image": "colocated-icon",
+        "icon-size": 1,
+        "icon-anchor": "center", // Center the icon
+        "icon-allow-overlap": true,
+        "icon-ignore-placement": true,
+      },
+      paint: {
+        "icon-translate": [15, -16], // Use translate instead of offset for consistency
       },
     });
 
@@ -248,9 +313,6 @@ export const createMap = (
           return;
         }
 
-        popup?.off("close", popupClosedCallback);
-
-        // Ease to new marker then open popup
         map
           .easeTo({
             center: [
@@ -302,6 +364,45 @@ export const createMap = (
         })[0] as GeoJSON.Feature<GeoJSON.Point>;
 
       const source = map.getSource("items-geojson") as GeoJSONSource;
+
+      // Get all leaves to check if co-located
+      const allLeaves: GeoJSON.Feature<GeoJSON.Point>[] =
+        (await source.getClusterLeaves(
+          clusterFeature.properties?.cluster_id,
+          Infinity,
+          0,
+        )) as GeoJSON.Feature<GeoJSON.Point>[];
+
+      // Check if all points are at the same location
+      const referenceCoord = allLeaves[0]?.geometry.coordinates;
+      const isColocated = allLeaves.every(
+        (leaf) =>
+          leaf.geometry.coordinates[0] === referenceCoord[0] &&
+          leaf.geometry.coordinates[1] === referenceCoord[1],
+      );
+
+      console.log(
+        `Cluster has ${allLeaves.length} points, co-located: ${isColocated}`,
+      );
+
+      // Update the set of co-located cluster IDs
+      const clusterId = clusterFeature.properties?.cluster_id;
+      if (isColocated) {
+        colocatedClusterIds.add(clusterId);
+      } else {
+        colocatedClusterIds.delete(clusterId);
+      }
+
+      // Track if this cluster will be spiderfied (at zoom 18)
+      if (isColocated && map.getZoom() >= 17.5) {
+        currentSpiderfiedClusterId = clusterId;
+      } else if (map.getZoom() < 18) {
+        currentSpiderfiedClusterId = null;
+      }
+
+      // Update badge visibility
+      updateBadgeVisibility(map);
+
       const features: GeoJSON.Feature<GeoJSON.Point>[] =
         (await source.getClusterLeaves(
           clusterFeature.properties?.cluster_id,
@@ -312,7 +413,18 @@ export const createMap = (
         clusterFeature.properties?.cluster_id,
       );
 
-      if (map.getZoom() < 18 && clusterExpansionZoom <= 18) {
+      // For co-located clusters, zoom by 3 levels to reach spiderfy faster
+      if (isColocated && map.getZoom() < 18) {
+        const targetZoom = Math.min(18, map.getZoom() + 3);
+        console.log(
+          `Co-located cluster: zooming from ${map.getZoom()} to ${targetZoom}`,
+        );
+        map.jumpTo({
+          center: features[0].geometry.coordinates as LngLatLike,
+          zoom: targetZoom,
+        });
+      } else if (map.getZoom() < 18 && clusterExpansionZoom <= 18) {
+        // Regular cluster behavior
         map.jumpTo({
           center: features[0].geometry.coordinates as LngLatLike,
           zoom: clusterExpansionZoom ?? undefined,
@@ -358,16 +470,16 @@ export const createMap = (
         const itemIx = feature.properties?.ix;
 
         if (popup?.isOpen() && popupIx === itemIx) {
-          console.log(`Popup for item ${itemIx} already open so toggle closed`);
+          console.log(
+            `Popup for item @${itemIx} already open so toggle closed`,
+          );
           popup?.remove();
           popupIx = undefined;
           popup = undefined;
           return;
         }
 
-        popup?.off("close", popupClosedCallback);
-
-        // Ease to new marker then open popup
+        // ease to a position so that the popup is fully visible
         map
           .easeTo({
             center: [
@@ -459,6 +571,10 @@ export const createMap = (
 
     map.on("zoomstart", () => {
       spiderfy.unspiderfyAll();
+      currentSpiderfiedClusterId = null;
+      if (map.getLayer("colocated-badge-circle")) {
+        updateBadgeVisibility(map);
+      }
     });
 
     map.on("mouseenter", "clusters", () => {
@@ -498,8 +614,6 @@ export const createMap = (
     map.addControl(new AttributionControl({ compact: true }), "top-right");
     map.addControl(new NavigationControl(), "top-right");
     disableRotation(map);
-
-    mapCreated();
   });
 
   return map;


### PR DESCRIPTION
### What? Why?
Sometimes multiple organisations are registered at the same location (co-located). When zoomed in these entities are represented by spiderfied markers, however, when zoomed out they are indistinguishable from any other cluster. As a consequence, it is often necessary to click and zoom numerous times before reaching the point where the cluster spiderfies. This can be frustrating as the user is forced into a repetative task without any indication of progress.

This enhancement adds a visual indicator, in the form of a badge, to the top right hand corner of co-located clusters. The badge is activated when a co-located cluster is clicked. In addition, co-located clusters now zoom three levels when clicked, reducing the journey to the end location.

Fixes #201 / #202 

### Code-specific details (for Reviewer)

**Co-located cluster badge feature:**

* Added a new SVG badge icon and circle layer (`colocated-badge-circle` and `colocated-badge-icon`) to visually indicate co-located clusters on the map, with logic to load and display the badge only for relevant clusters.
* Implemented the `updateBadgeVisibility` function to dynamically show or hide badges based on which clusters are co-located and whether they are currently spiderfied.

**Co-located cluster detection and interaction:**

* Added logic to detect when all points in a cluster are co-located, track these cluster IDs in a set, and update badge visibility accordingly during cluster click events.
* Modified cluster click behavior to zoom in by 3 levels for co-located clusters, helping users reach the spiderfy threshold more quickly, and to update the spiderfied cluster state.

**Event handling improvements:**
* Ensured badge visibility and spiderfied state are reset appropriately on map zoom events.

### What should we test? (for QA)

- Navigate to India
- Click on a large cluster
- At each zoom level click on the largest cluster
  - You should eventually hit a co-located cluster 
  - A co-located cluster badge should appear
  - You should zoom three level at a time
- Click until you reach maximum zoom
  - When the cluster spiderfies the badge should disappear
- Zoom out and the badge should re-appear
  - It should disappear when the cluster envelopes another marker / cluster
- Navigate to another large cluster and repeat

<br/>