### PR TITLE
261 [CWM] Update Primary CTA Colour

### DIFF
--- a/apps/front-end/src/components/common/standardButton/StandardButton.tsx
+++ b/apps/front-end/src/components/common/standardButton/StandardButton.tsx
@@ -4,6 +4,7 @@ import Button from "@mui/material/Button";
 interface ButtonProps {
   variant?: "contained" | "outlined" | "text";
   color?: "primary" | "secondary";
+  intent?: "cta";
   children: React.ReactNode;
   disabled?: boolean;
   buttonAction?: () => void;
@@ -15,12 +16,14 @@ const StandardButton = ({
   children,
   disabled = false,
   buttonAction,
+  intent,
   ...props
 }: ButtonProps) => {
   return (
     <Button
       variant={variant}
       color={color}
+      intent={intent}
       onClick={buttonAction}
       disabled={disabled}
       {...props}

--- a/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
+++ b/apps/front-end/src/components/panel/applyFilters/ApplyFilters.tsx
@@ -52,7 +52,7 @@ const ApplyFilters = ({
         </StandardButton>
       </div>
       <div>
-        <StandardButton buttonAction={buttonAction} disabled={disabled}>
+        <StandardButton intent="cta" buttonAction={buttonAction} disabled={disabled}>
           {buttonText}
         </StandardButton>
       </div>

--- a/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/ResultsPanel.tsx
@@ -117,7 +117,10 @@ const ResultsPanel = () => {
         }}
       >
         <StyledButtonContainer>
-          <StandardButton buttonAction={handleClearSearch}>
+          <StandardButton
+            intent="cta"
+            buttonAction={handleClearSearch}
+          >
             {t("clear_search")}
           </StandardButton>
           {!isMedium && <CloseButton buttonAction={handlePanelClose} />}

--- a/apps/front-end/src/components/panel/resultsPanel/results/Results.tsx
+++ b/apps/front-end/src/components/panel/resultsPanel/results/Results.tsx
@@ -87,6 +87,7 @@ const Results = () => {
         variant="h4"
         component="h4"
         sx={{
+          marginTop: "var(--spacing-medium)",
           color: "var(--color-neutral-tint)",
           padding: "0 var(--spacing-medium)",
           "@media (min-width: 768px)": {

--- a/apps/front-end/src/theme/GlobalCSSVariables.tsx
+++ b/apps/front-end/src/theme/GlobalCSSVariables.tsx
@@ -4,6 +4,7 @@ import type { FC } from "react";
 // Resuable CSS variables
 const rootVariables = {
   "--color-primary": "#4D8C63",
+  "--color-primary-rgb": "77, 140, 99",
   "--color-primary-light": "#639C7A",
   "--color-secondary": "#3E4854",
   "--color-secondary-light": "#535F6D",

--- a/apps/front-end/src/theme/mui.d.ts
+++ b/apps/front-end/src/theme/mui.d.ts
@@ -1,0 +1,7 @@
+import "@mui/material/Button";
+
+declare module "@mui/material/Button" {
+  interface ButtonOwnProps {
+    intent?: "cta";
+  }
+}

--- a/apps/front-end/src/theme/theme.ts
+++ b/apps/front-end/src/theme/theme.ts
@@ -143,7 +143,7 @@ const themeOptions: ThemeOptions = {
           props: { variant: "contained", intent: "cta" },
           style: {
             backgroundImage:
-              "linear-gradient(175deg, #639C7A, #4D8C63, #30583e)",
+              "linear-gradient(175deg, #639C7A 0%,  #639C7A 4%, #4D8C63 55%, #30583e 100%)",
             backgroundColor: "var(--color-primary)",
             color: "#fff",
             transition: "filter 0.25s ease-out, box-shadow 0.25s ease-out",
@@ -154,7 +154,7 @@ const themeOptions: ThemeOptions = {
             "&:hover": {
               filter: "brightness(0.93)",
               boxShadow:
-                "0 0 8px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255, 0.18)",
+                "0 0 8px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255, 0.15)",
             },
 
             "&.Mui-focusVisible": {

--- a/apps/front-end/src/theme/theme.ts
+++ b/apps/front-end/src/theme/theme.ts
@@ -115,6 +115,7 @@ const themeOptions: ThemeOptions = {
       defaultProps: {
         disableRipple: true,
       },
+
       styleOverrides: {
         root: {
           borderRadius: "var(--border-radius-small)",
@@ -137,6 +138,40 @@ const themeOptions: ThemeOptions = {
           },
         },
       },
+      variants: [
+        {
+          props: { variant: "contained", intent: "cta" },
+          style: {
+            backgroundImage:
+              "linear-gradient(175deg, #639C7A, #4D8C63, #386648)",
+            backgroundColor: "var(--color-primary)",
+            color: "#fff",
+            transition: "filter 0.25s ease-out, box-shadow 0.25s ease-out",
+            filter: "brightness(1)",
+            boxShadow:
+              "0 0 8px rgba(0,0,0,0.25), inset 0 0 0 1px rgba(255,255,255,0.18)",
+
+            "&:hover": {
+              filter: "brightness(0.92)",
+              boxShadow:
+                "0 0 8px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.18)",
+            },
+
+            "&.Mui-focusVisible": {
+              outline: "2px solid rgba(255, 255, 255, 0.35)",
+              outlineOffset: "2px",
+            },
+
+            "&.Mui-disabled": {
+              backgroundImage: "none",
+              backgroundColor: "rgba(77, 140, 99, 0.35)",
+              border: "1px solid rgba(77, 140, 99, 0.20)",
+              color: "rgba(255, 255, 255, 0.7)",
+              boxShadow: "none",
+            },
+          },
+        },
+      ],
     },
     MuiIconButton: {
       styleOverrides: {

--- a/apps/front-end/src/theme/theme.ts
+++ b/apps/front-end/src/theme/theme.ts
@@ -143,7 +143,7 @@ const themeOptions: ThemeOptions = {
           props: { variant: "contained", intent: "cta" },
           style: {
             backgroundImage:
-              "linear-gradient(175deg, #639C7A, #4D8C63, #386648)",
+              "linear-gradient(175deg, #639C7A, #4D8C63, #30583e)",
             backgroundColor: "var(--color-primary)",
             color: "#fff",
             transition: "filter 0.25s ease-out, box-shadow 0.25s ease-out",
@@ -152,9 +152,9 @@ const themeOptions: ThemeOptions = {
               "0 0 8px rgba(0,0,0,0.25), inset 0 0 0 1px rgba(255,255,255,0.18)",
 
             "&:hover": {
-              filter: "brightness(0.92)",
+              filter: "brightness(0.93)",
               boxShadow:
-                "0 0 8px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.18)",
+                "0 0 8px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255, 0.18)",
             },
 
             "&.Mui-focusVisible": {
@@ -164,8 +164,8 @@ const themeOptions: ThemeOptions = {
 
             "&.Mui-disabled": {
               backgroundImage: "none",
-              backgroundColor: "rgba(77, 140, 99, 0.35)",
-              border: "1px solid rgba(77, 140, 99, 0.20)",
+              backgroundColor: "rgba(var(--color-primary-rgb), 0.35)",
+              border: "1px solid rgba(var(--color-primary-rgb), 0.20)",
               color: "rgba(255, 255, 255, 0.7)",
               boxShadow: "none",
             },


### PR DESCRIPTION
### What? Why?
Refined the primary call-to-action (CTA) buttons to improve visibility based on user feedback, while maintaining the MykoMap palette and overall UI consistency.

Fixes #261

**Component and API updates:**

* Added an optional `intent` prop (with value "cta") to the `StandardButton` component's interface and passed it through to the underlying MUI `Button` component. (`StandardButton.tsx`) [[1]](diffhunk://#diff-d1276d0143573fb06ed36f76c340471a7542915a589426b4ff4daeca805e5870R7) [[2]](diffhunk://#diff-d1276d0143573fb06ed36f76c340471a7542915a589426b4ff4daeca805e5870R19-R26)

**Usage updates:**

* Updated usages of `StandardButton` in `ApplyFilters` and `ResultsPanel` to use `intent="cta"` for primary action buttons, ensuring consistent visual emphasis for key actions. (`ApplyFilters.tsx`, `ResultsPanel.tsx`) [[1]](diffhunk://#diff-ad00004172893b2458508882fe610d048189e43ee3b41e5aae06eeb339933aa7L55-R55) [[2]](diffhunk://#diff-459962da47b2fc20915ddecc08d3785c6939687c1f97bd667d42236b0ee4da2dL120-R123)

**Theming and styling:**

* Added a custom variant for `Button` components with `variant="contained"` and `intent="cta"`, applying a gradient background, custom hover, focus, and disabled styles in the theme. (`theme.ts`)
* Introduced a new CSS variable `--color-primary-rgb` for use in theme styling. (`GlobalCSSVariables.tsx`)

### What should we test? (for QA)

**Desktop**

- Click on the **Directory** tab
- Click on an entry
- Check the **Clear Search** button:
  - Aligns with the current MM palette
  - Has increased prominence
  - Hover state behaves as expected

 
**Mobile**

- Tap on the **Search** tab
- Select a filter
- Check the **Apply Filters** button:
  - Uses the updated CTA styling
  - Displays correctly in default and pressed states

<br>