### PR TITLE
219 cwm search input default on desktop

### DIFF
--- a/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
+++ b/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
@@ -58,6 +58,7 @@ const SearchBox = ({
     <Box sx={{ position: "relative", marginTop: "var(--spacing-medium)" }}>
       <StyledSearchBox
         id="search-input"
+        autoFocus={true}
         value={value}
         onChange={onChange}
         onKeyUp={(event) => {

--- a/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
+++ b/apps/front-end/src/components/panel/searchPanel/searchBox/SearchBox.tsx
@@ -5,6 +5,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import { styled } from "@mui/material/styles";
 import IconButton from "@mui/material/IconButton";
 import CancelIcon from "@mui/icons-material/Cancel";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTranslation } from "react-i18next";
 
 const StyledSearchBox = styled(OutlinedInput)(() => ({
@@ -53,12 +54,13 @@ const SearchBox = ({
   clearSearch,
 }: SearchBoxProps) => {
   const { t } = useTranslation();
+  const isMedium = useMediaQuery("(min-width: 897px)");
 
   return (
     <Box sx={{ position: "relative", marginTop: "var(--spacing-medium)" }}>
       <StyledSearchBox
         id="search-input"
-        autoFocus={true}
+        autoFocus={isMedium}
         value={value}
         onChange={onChange}
         onKeyUp={(event) => {


### PR DESCRIPTION
#### What? Why?

Fixes #219 

When the search tab is opened, autofocus the search input so users can type straight away. This is only applied on desktop to prevent the keyboard popping up on mobile.

#### Code-specific details (for Reviewer)

- SearchBox.tsx is the only file changed
- Uses the >= 897px convention I found everywhere else (in the results panel for example)
- I looked at adding a test but mocking desktop/mobile size seems still to be a work in progress

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

- Open map on desktop: click search tab - type and text should go into search tab
- On mobile open search tab, keyboard should not pop up and you should have to click in the search input

#### Deployment notes

None