### PR TITLE
85 About Box supports multiple languages

### DIFF
--- a/apps/front-end/src/components/panel/aboutPanel/AboutPanel.tsx
+++ b/apps/front-end/src/components/panel/aboutPanel/AboutPanel.tsx
@@ -15,7 +15,7 @@ const AboutPanel = () => {
   // This is a little messy to edit but means everything goes in config.json.
   // In future we might want to break this out into localised md files.
   const hasAboutContentInConfig = i18n.exists("about_content");
-  
+
   useEffect(() => {
     if (!hasAboutContentInConfig) {
       fetch(`${import.meta.env.VITE_API_URL}/dataset/${getDatasetId()}/about`)
@@ -27,7 +27,9 @@ const AboutPanel = () => {
     }
   });
 
-  const content = hasAboutContentInConfig ? t("about_content") : aboutMarkdownContent;
+  const content = hasAboutContentInConfig
+    ? t("about_content")
+    : aboutMarkdownContent;
   return (
     <>
       <Heading title={t("about")} />

--- a/apps/front-end/src/components/panel/aboutPanel/AboutPanel.tsx
+++ b/apps/front-end/src/components/panel/aboutPanel/AboutPanel.tsx
@@ -6,23 +6,33 @@ import { useEffect, useState } from "react";
 import { getDatasetId } from "../../../utils/window-utils";
 
 const AboutPanel = () => {
-  const { t } = useTranslation();
-  const [aboutContent, setAboutContent] = useState("");
+  const { t, i18n } = useTranslation();
+  const [aboutMarkdownContent, setAboutMarkdownContent] = useState("");
 
+  // Fetching the markdown to render in the about panel from the ui vocab
+  // string t("about_content") - if this exists it overwrites the
+  // non-localised about.md from the dataset.
+  // This is a little messy to edit but means everything goes in config.json.
+  // In future we might want to break this out into localised md files.
+  const hasAboutContentInConfig = i18n.exists("about_content");
+  
   useEffect(() => {
-    fetch(`${import.meta.env.VITE_API_URL}/dataset/${getDatasetId()}/about`)
-      .then((response) => response.text())
-      .then((text) => {
-        console.log("About content", text);
-        setAboutContent(text);
-      });
+    if (!hasAboutContentInConfig) {
+      fetch(`${import.meta.env.VITE_API_URL}/dataset/${getDatasetId()}/about`)
+        .then((response) => response.text())
+        .then((text) => {
+          console.log("About content", text);
+          setAboutMarkdownContent(text);
+        });
+    }
   });
 
+  const content = hasAboutContentInConfig ? t("about_content") : aboutMarkdownContent;
   return (
     <>
       <Heading title={t("about")} />
       <ContentPanel>
-        <MuiMarkdown>{aboutContent}</MuiMarkdown>
+        <MuiMarkdown>{content}</MuiMarkdown>
       </ContentPanel>
     </>
   );

--- a/docs/config.md
+++ b/docs/config.md
@@ -193,6 +193,32 @@ The `map` field has 1 subfield
 
 <br />
 
+## About Panel Content
+
+The about panel displays the content of `about.md` - this is not localised.
+
+To provide translatable panel content add an `about_content` key to each languages `vocabs.ui` term in `config.json`. The value is a markdown string. If present it overrides `about.md`.
+
+```
+"ui": {
+    "en": {
+      "terms": {
+        "about_content" : "Welcome to **the map**!\n\nMore details..."
+        ...
+      }
+    }
+}
+```
+
+Markdown is hard to edit in json. You can use jq on the command line to edit it:
+
+`jq --rawfile md about.fr.md '.vocabs.ui.fr.terms.about_content = $md' config.json > t && mv 
+ t config.json`
+
+Extract the markdown for a language:
+
+`jq -r '.vocabs.ui.en.terms.about_content' config.json > about.en.md`
+
 ## Pluralisation
 
 Pluralisation rules can differ per language, requiring the use of extra suffixes. `zero`, `one` and `other` are sufficient for English, Spanish, French and Hindi, and fine for our current instance of CWM. However, Welsh and Arabic have six categories according to **[CLDR ](https://cldr.unicode.org/index/cldr-spec/plural-rules)** and **[i18next](https://www.i18next.com/translation-function/plurals)** follows this:

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -638,17 +638,20 @@ Inside these top-level directories are a number of mandatory data
 files, and a sub-directory named `items` which contains a data file
 for each of the dataset's items.
 
-### `about.md` (mandatory)
+### `about.md` (optional)
+
+> [!NOTE] This has been superseeded by the localised about_config
+> vocab ui term in config.json
+> See the [config](config.md#about-panel-content) ref for more.
 
 This file contains a free-form human-readable description of the
 dataset in Markdown format.
 
+If this file exists and there is no ui term then:
+
 It will be shown in the "about" panel of the map when this dataset is
 selected. You can put anything you like in here, but you should keep
 this viewing context in mind.
-
-> [!WARNING] Currently there is no localisation support for this file,
-> this should be added in future.
 
 ### `config.json` (mandatory)
 


### PR DESCRIPTION
#### What? Why?

Fixes #85

The about box panel content was pulled from a markdown file (about.md) and was not translated.

Now the about panel content is fetched from a ui vocab string - about_content

Allows the new text from DotCoop to be used with links.

#### Code-specific details (for Reviewer)

I've left the old about.md path as a fallback (for example for Powys) but if there is a ui vocab string it overrides the markdown files.

Design doc: See #85

#### Checklist

- [x] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [x] Checked that all automated tests pass

#### What should we test? (for QA)

You can use the config.json from cwm-latest on the [cwm-translate-about-box branch](https://github.com/DigitalCommons/cwm-test-data/tree/cwm-translate-about-box)

- Edit config.json in your dataset and add vocabs.ui.en.terms.about_content and verify it is displaued
- Remove about_content and verify it falls back to about.md
- Switch languages with ?lang=fr and add about_content for that and verify it is displayed
- Verify markdown links and formatting render correctly

#### Deployment notes

See the data pipeline changes here - the markdown files will get piped into the config.json when it runs - https://github.com/DigitalCommons/data-pipelines/pull/3/changes