### PR TITLE
[front-end] revert map key translations

### DIFF
--- a/apps/front-end/src/components/map/mapKey/MapKey.tsx
+++ b/apps/front-end/src/components/map/mapKey/MapKey.tsx
@@ -94,7 +94,7 @@ const MapKeyButton = ({
       aria-controls="map-key"
       aria-expanded={isOpen}
     >
-      <FormatListBulletedIcon /> {isMedium ? t("Map Key") : t("Key")}
+      <FormatListBulletedIcon /> {isMedium ? t("mapKey") : t("key")}
     </StyledMapKeyButton>
   );
 };


### PR DESCRIPTION
#### What? Why?

Reverts the erroneous changes I made in `MapKeyButton` to the `mapKey` and `map` translations during issue #265.

#### Code-specific details (for Reviewer)

* Updated the button label in `MapKeyButton` to use the translation keys `mapKey` and `key` instead of `Map Key` and `Key` for improved translation consistency.

Design doc: <!-- Insert link here -->

#### Checklist

- [ ] Updated or added any necessary docs in `docs/`
- [ ] Added UTs
- [ ] Checked that all automated tests pass

#### What should we test? (for QA)

<!-- List which features should be tested and how.
     Also think of other parts of the app which could be affected
     by your change. -->

- Click '...'

#### Deployment notes

<!-- Is there anything to note that needs to be done on deployment to
     ensure the PR behaves correctly? -->
