### PR TITLE
Don't clobber the about.md file if it exists

### DIFF
--- a/apps/back-end/src/dataset.ts
+++ b/apps/back-end/src/dataset.ts
@@ -232,10 +232,14 @@ export class DatasetWriter {
       await searchableFile.write("\n]}");
 
       // Write a stub about.md file
-      writeFileSync(
-        join(dirPath, "about.md"),
-        "created on: " + new Date().toLocaleString() + "\n",
-      );
+      // But only if one wasn't supplied in the dataset
+      const aboutPath = join(dirPath, "about.md");
+      if (!existsSync(aboutPath)) {
+        writeFileSync(
+          aboutPath,
+          "created on: " + new Date().toLocaleString() + "\n",
+        );
+      }
     } catch (e) {
       if (e instanceof ValidationError)
         throw new Error(`validation error parsing item #${stats.counter}`, {


### PR DESCRIPTION
#### What? Why?

The about.md text is getting replaced in the live version with text saying "created on:" - this is a fallback that should only replace the text if about.md doesn't exist.